### PR TITLE
Fix tree and snap walking. 

### DIFF
--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -93,6 +93,11 @@ class Path:
   #TODO This function returns leading '/' on relations.
   #TODO This function returns '/' for matches. It should return '.'
   #TODO This function doesn't handle "complex" relationships.
+  #XXX This function leads to confusion. It returns a string when mostly you
+  # want to mess with Paths. It should only be called in user output schenatios.
+  #TODO Check where this is called and try to stop calling it.
+  #TODO Rename this to somthing which disourages use.
+  #TODO Rename this so the string return value is called out.
   def relative_to(self, relative, leading_sep=True):
     assert isinstance(relative, Path)
     if leading_sep == True:

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -68,12 +68,12 @@ class TreeSnapshot(Snapshot):
     udd = self.udd
     exclude = self.exclude
     def tree_snap_iterator():
-      last_str = None
+      last_path = None
       for path, type_ in root.entries(exclude):
         tree_str = path.relative_to(root)
-        if last_str:
-          assert last_str < tree_str, "Order error: %s < %s" % (last_str, tree_str) #TODO this is a string compare, not a Path compare.
-        last_str = tree_str
+        if last_path:
+          assert last_path < path, "Order error: %s < %s" % (last_path, Path)
+        last_path = path
         if type_ == "link":
           ud_str = path.readlink().relative_to(udd)
         elif type_ == "dir":

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -23,6 +23,12 @@ class SnapshotItem:
     self._csum = csum
     self._snap = snap
 
+  def __cmp__(self, other):
+    assert isinstance(other, SnapshotItem)
+    self_path = Path(self._path)
+    other_path = Path(other._path)
+    return cmp(self_path, other_path)
+
   def get_tuple(self):
     if self._ref:
       ref = self._ref
@@ -94,7 +100,7 @@ class KeySnapshot(Snapshot):
 
   def __iter__(self):
     def key_snap_iterator():
-      last_path = None
+      last_item = None
       for item in self.data:
         if isinstance(item, list):
           assert len(item) == 3
@@ -102,9 +108,9 @@ class KeySnapshot(Snapshot):
         elif isinstance(item, dict):
           params = dict(item, splitter=self._splitter, reverser=self._reverser, snap=self._name)
           parsed = SnapshotItem(**params)
-        if last_path:
-          assert last_path < parsed._path, "Order Error: %s < %s" % (last_path, parsed._path) #TODO this is a string compare, not a Path compare.
-        last_path = parsed._path
+        if last_item:
+          assert last_item < parsed, "Order Error: %s < %s" % (last_item, parsed)
+        last_item = parsed
         yield parsed
     return key_snap_iterator()
 

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -69,20 +69,20 @@ class TreeSnapshot(Snapshot):
     exclude = self.exclude
     def tree_snap_iterator():
       last_path = None
-      for entry, type_ in root.entries(exclude):
-        tree_path = entry.relative_to(root)
-        if last_path:
-          assert last_path < tree_path, "Order error: %s < %s" % (last_path, tree_path)
+      for entry, type_ in root.entries(exclude): #TODO entry is really a Path.
+        tree_path = entry.relative_to(root) #TODO tree_path is really a string.
+        if last_path: #TODO last_path is just what tree_path is.
+          assert last_path < tree_path, "Order error: %s < %s" % (last_path, tree_path) #TODO this is a string compare, not a Path compare.
         last_path = tree_path
         if type_ == "link":
-          ud_path = entry.readlink().relative_to(udd)
+          ud_path = entry.readlink().relative_to(udd) #TODO ud_path is a string.
         elif type_ == "dir":
           ud_path = None
         elif type_ == "file":
           continue
         else:
           raise ValueError("Encounted unexpected type %s for path %s" % (type_, entry))
-        yield SnapshotItem(tree_path, type_, ud_path, reverser=self.reverser)
+        yield SnapshotItem(tree_path, type_, ud_path, reverser=self.reverser) #TODO we do this reverser thing because ud_path is messed up string with slashes.
     return tree_snap_iterator()
 
 class KeySnapshot(Snapshot):
@@ -103,7 +103,7 @@ class KeySnapshot(Snapshot):
           params = dict(item, splitter=self._splitter, reverser=self._reverser, snap=self._name)
           parsed = SnapshotItem(**params)
         if last_path:
-          assert last_path < parsed._path, "Order Error: %s < %s" % (last_path, parsed._path)
+          assert last_path < parsed._path, "Order Error: %s < %s" % (last_path, parsed._path) #TODO this is a string compare, not a Path compare.
         last_path = parsed._path
         yield parsed
     return key_snap_iterator()

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -68,21 +68,21 @@ class TreeSnapshot(Snapshot):
     udd = self.udd
     exclude = self.exclude
     def tree_snap_iterator():
-      last_path = None
-      for entry, type_ in root.entries(exclude): #TODO entry is really a Path.
-        tree_path = entry.relative_to(root) #TODO tree_path is really a string.
-        if last_path: #TODO last_path is just what tree_path is.
-          assert last_path < tree_path, "Order error: %s < %s" % (last_path, tree_path) #TODO this is a string compare, not a Path compare.
-        last_path = tree_path
+      last_str = None
+      for path, type_ in root.entries(exclude):
+        tree_str = path.relative_to(root)
+        if last_str:
+          assert last_str < tree_str, "Order error: %s < %s" % (last_str, tree_str) #TODO this is a string compare, not a Path compare.
+        last_str = tree_str
         if type_ == "link":
-          ud_path = entry.readlink().relative_to(udd) #TODO ud_path is a string.
+          ud_str = path.readlink().relative_to(udd)
         elif type_ == "dir":
-          ud_path = None
+          ud_str = None
         elif type_ == "file":
           continue
         else:
           raise ValueError("Encounted unexpected type %s for path %s" % (type_, entry))
-        yield SnapshotItem(tree_path, type_, ud_path, reverser=self.reverser) #TODO we do this reverser thing because ud_path is messed up string with slashes.
+        yield SnapshotItem(tree_str, type_, ud_str, reverser=self.reverser) #TODO we do this reverser thing because ud_str is messed up string with slashes.
     return tree_snap_iterator()
 
 class KeySnapshot(Snapshot):

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -88,7 +88,7 @@ class TreeSnapshot(Snapshot):
           continue
         else:
           raise ValueError("Encounted unexpected type %s for path %s" % (type_, entry))
-        yield SnapshotItem(tree_str, type_, ud_str, reverser=self.reverser) #TODO we do this reverser thing because ud_str is messed up string with slashes.
+        yield SnapshotItem(tree_str, type_, ud_str, reverser=self.reverser)
     return tree_snap_iterator()
 
 class KeySnapshot(Snapshot):


### PR DESCRIPTION
When I added tree and snap order checks, I didn't realize I was dealing with strings in the Snapshot unit, rather than Paths. 
