### PR TITLE
Move from using str by default to using safetype

### DIFF
--- a/farmfs/__init__.py
+++ b/farmfs/__init__.py
@@ -3,13 +3,13 @@ from farmfs.volume import FarmFSVolume
 from farmfs.fs import Path
 from farmfs.keydb import KeyDBWindow
 from func_prototypes import typed, returned
-from farmfs.util import take
+from farmfs.util import take, ingest
 try:
     from os import getcwdu
-    getcwd_utf = lambda : str(getcwdu().encode('utf-8'))
+    getcwd_utf = lambda : ingest(getcwdu())
 except ImportError:
     from os import getcwdb
-    getcwd_utf = lambda : str(getcwdb().decode('utf-8'))
+    getcwd_utf = lambda : ingest(getcwdb())
 try:
     from itertools import imap
 except ImportError:

--- a/farmfs/farmdbg.py
+++ b/farmfs/farmdbg.py
@@ -71,7 +71,7 @@ def main():
     elif args['snap']:
       print(JSONEncoder(ensure_ascii=False).encode(encode_snapshot(vol.snapdb.read(args['<snapshot>']))))
     elif args['userdata']:
-      print(JSONEncoder(ensure_ascii=False).encode(list(map(str, map(lambda x: x[0], walk([vol.udd], [str(vol.mdd)], ["file"]))))))
+      print(JSONEncoder(ensure_ascii=False).encode(list(map(safetype, map(lambda x: x[0], walk([vol.udd], [safetype(vol.mdd)], ["file"]))))))
     elif args['keys']:
       print(JSONEncoder(ensure_ascii=False).encode(vol.keydb.list()))
   elif args['checksum']:
@@ -88,7 +88,7 @@ def main():
     f.symlink(t)
   elif args['rewrite-links']:
     target = Path(args['<target>'], cwd)
-    for (link, _type) in walk([target], [str(vol.mdd)], ["link"]):
+    for (link, _type) in walk([target], [safetype(vol.mdd)], ["link"]):
       new = vol.repair_link(link)
       if new is not None:
           print("Relinked %s to %s" % (link.relative_to(cwd, leading_sep=False), new))

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -203,7 +203,7 @@ class Path:
     return hash(self._path)
 
   def join(self, child):
-    assert isinstance(child, safetype)
+    child = safetype(child)
     try:
       output = Path( self._path + sep + child)
     except UnicodeDecodeError as e:

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -50,6 +50,7 @@ class Path:
         assert isinstance(frame, Path)
         assert not isabs(path), "path %s is required to be relative when a frame %s is provided" % (path, frame)
         self._path = frame.join(path)._path
+    assert isinstance(self._path, safetype)
 
   def __unicode__(self):
     return self._path.encode('utf-8')

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -180,8 +180,7 @@ class Path:
       while len(buf) > 0:
         hasher.update(buf)
         buf = fd.read(_BLOCKSIZE)
-      digest = hasher.hexdigest()
-      assert isinstance(digest, bytes)
+      digest = safetype(hasher.hexdigest())
       return digest
 
   def __cmp__(self, other):
@@ -260,7 +259,6 @@ class Path:
     return chmod(self._path, mode)
 
 @returned(Path)
-@typed(str, Path)
 def userPath2Path(arg, frame):
     """
     Building paths using conventional POSIX systems will discard CWD if the
@@ -273,6 +271,7 @@ def userPath2Path(arg, frame):
     userPath2Path checks to see if the provided path is absolute, and if not,
     adds the CWD frame.
     """
+    arg = ingest(arg)
     if isabs(arg):
       return Path(arg)
     else:
@@ -342,7 +341,7 @@ def ensure_symlink(path, orig):
   assert orig.exists()
   ensure_symlink_unsafe(path, orig._path)
 
-@typed(Path, str)
+@typed(Path, safetype)
 def ensure_symlink_unsafe(path, orig):
   parent = path.parent()
   assert parent != path, "Path and parent were the same!"

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -224,6 +224,7 @@ class Path:
       exclude = [exclude]
     exclude = list(exclude)
     for excluded in exclude:
+      excluded = safetype(excluded)
       assert isinstance(excluded, safetype)
     return self._entries(exclude)
 

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -23,7 +23,7 @@ from func_prototypes import typed, returned
 from glob import fnmatch
 from fnmatch import fnmatchcase
 from functools import total_ordering
-from farmfs.util import ingest
+from farmfs.util import ingest, safetype
 
 _BLOCKSIZE = 65536
 
@@ -196,7 +196,7 @@ class Path:
     return hash(self._path)
 
   def join(self, child):
-    assert isinstance(child, str)
+    assert isinstance(child, safetype)
     try:
       output = Path( self._path + sep + child)
     except UnicodeDecodeError as e:
@@ -206,7 +206,7 @@ class Path:
   def dir_gen(self):
     """Generates the set of Paths under this directory"""
     assert self.isdir(), "%s is not a directory" % self._path
-    assert isinstance(self._path, str)
+    assert isinstance(self._path, safetype)
     names = listdir(self._path)
     for name in names:
       child = self.join(name)
@@ -217,7 +217,7 @@ class Path:
       exclude = [exclude]
     exclude = list(exclude)
     for excluded in exclude:
-      assert isinstance(excluded, str)
+      assert isinstance(excluded, safetype)
     return self._entries(exclude)
 
   def _entries(self, exclude):

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -27,6 +27,12 @@ from farmfs.util import ingest, safetype
 
 _BLOCKSIZE = 65536
 
+LINK=u'link'
+FILE=u'file'
+DIR=u'dir'
+
+TYPES=[LINK, FILE, DIR]
+
 @total_ordering
 class Path:
   def __init__(self, path, frame=None):
@@ -224,17 +230,17 @@ class Path:
     if self._excluded(exclude):
       pass
     elif self.islink():
-      yield (self, "link")
+      yield (self, LINK)
     elif self.isfile():
-      yield (self, "file")
+      yield (self, FILE)
     elif self.isdir():
-      yield (self, "dir")
+      yield (self, DIR)
       children = self.dir_gen()
       for dir_entry in sorted(children):
         for x in dir_entry._entries(exclude):
           yield x
     else:
-      raise ValueError("%s is not a file/dir/link" % self)
+      raise ValueError("%s is not in %s" % (self, types))
 
   def _excluded(self, exclude):
     for excluded in exclude:

--- a/farmfs/keydb.py
+++ b/farmfs/keydb.py
@@ -8,7 +8,7 @@ from errno import ENOENT as NoSuchFile
 from errno import EISDIR as IsDirectory
 from os.path import sep
 from func_prototypes import typed, returned
-from farmfs.util import ingest, egest
+from farmfs.util import ingest, egest, safetype
 
 @returned(str)
 @typed(bytes)
@@ -23,7 +23,7 @@ class KeyDB:
 
   #TODO I DONT THINK THIS SHOULD BE A PROPERTY OF THE DB UNLESS WE HAVE SOME ITERATOR BASED RECORD TYPE.
   def write(self, key, value):
-    assert isinstance(key, str)
+    key = safetype(key)
     value_json = JSONEncoder(ensure_ascii=False).encode(value)
     value_bytes = egest(value_json)
     value_hash = egest(checksum(value_bytes))
@@ -35,7 +35,7 @@ class KeyDB:
       f.write(b"\n")
 
   def readraw(self, key):
-    assert isinstance(key, str)
+    key = safetype(key)
     try:
       with self.root.join(key).open('rb') as f:
         obj_bytes = f.readline().strip()
@@ -62,7 +62,7 @@ class KeyDB:
   def list(self, query=None):
     if query is None:
       query = ""
-    assert isinstance(query, str)
+    query = safetype(query)
     query_path = self.root.join(query)
     assert self.root in query_path.parents(), "%s is not a parent of %s" % (self.root, query_path)
     if query_path.exists and query_path.isdir():
@@ -73,13 +73,13 @@ class KeyDB:
       return []
 
   def delete(self, key):
-    assert isinstance(key, str)
+    key = safetype(key)
     path = self.root.join(key)
     path.unlink(clean=self.root)
 
 class KeyDBWindow(KeyDB):
   def __init__(self, window, keydb):
-    assert isinstance(window, str)
+    window = safetype(window)
     assert isinstance(keydb, KeyDB)
     self.prefix = window + sep
     self.keydb = keydb

--- a/farmfs/keydb.py
+++ b/farmfs/keydb.py
@@ -26,7 +26,7 @@ class KeyDB:
     assert isinstance(key, str)
     value_json = JSONEncoder(ensure_ascii=False).encode(value)
     value_bytes = egest(value_json)
-    value_hash = checksum(value_bytes).encode('utf-8')
+    value_hash = egest(checksum(value_bytes))
     key_path = self.root.join(key)
     with ensure_file(key_path, 'wb') as f:
       f.write(value_bytes)

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -1,4 +1,4 @@
-from farmfs.fs import Path, LINK, DIR, FILE
+from farmfs.fs import Path, LINK, DIR, FILE, ingest
 from func_prototypes import typed
 from delnone import delnone
 from os.path import sep
@@ -23,9 +23,9 @@ class SnapshotItem:
         raise ValueError("checksum should be specified for links")
       else:
         assert isinstance(csum, safetype)
-    self._path = path
-    self._type = type
-    self._csum = csum
+    self._path = ingest(path)
+    self._type = ingest(type)
+    self._csum = csum and ingest(csum) # csum can be None.
 
   #TODO create a path comparator. cmp has different semantics.
   def __cmp__(self, other):
@@ -54,6 +54,7 @@ class SnapshotItem:
             csum=self._csum))
 
   def pathStr(self):
+    assert isinstance(self._path, safetype)
     return self._path;
 
   def is_dir(self):
@@ -119,8 +120,11 @@ class KeySnapshot(Snapshot):
         if isinstance(item, list):
           assert len(item) == 3
           (path_str, type_, ref) = item
+          assert isinstance(path_str, safetype)
+          assert isinstance(type_, safetype)
           if ref is not None:
             csum = self._reverser(ref)
+            assert isinstance(csum, safetype)
           else:
             csum = None
           parsed = SnapshotItem(path_str, type_, csum)

--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -21,8 +21,6 @@ class SnapshotItem:
     if type == LINK:
       if csum is None:
         raise ValueError("checksum should be specified for links")
-      else:
-        assert isinstance(csum, safetype)
     self._path = ingest(path)
     self._type = ingest(type)
     self._csum = csum and ingest(csum) # csum can be None.

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -46,7 +46,10 @@ def op_doer(op):
 stream_op_doer = fmap(op_doer)
 
 def main():
-  args = docopt(USAGE)
+    return farmfs_ui(sys.argv, cwd)
+
+def farmfs_ui(argv, cwd):
+  args = docopt(USAGE, argv)
   exitcode = 0
   if args['mkfs']:
     root = userPath2Path(args['<root>'] or ".", cwd)
@@ -223,4 +226,4 @@ def main():
                 consume)(diff)
       else: # diff
         pipeline(stream_delta_printr, consume)(diff)
-  exit(exitcode)
+  return exitcode

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -46,7 +46,8 @@ def op_doer(op):
 stream_op_doer = fmap(op_doer)
 
 def main():
-    return farmfs_ui(sys.argv, cwd)
+    result = farmfs_ui(sys.argv[1:], cwd)
+    exit(result)
 
 def farmfs_ui(argv, cwd):
   args = docopt(USAGE, argv)

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -7,11 +7,16 @@ except ImportError:
     imap = map
 
 try:
+  #Python2
   rawtype = unicode
   raw2str = lambda r: r.encode('utf-8')
+  str2raw = lambda s: s.encode('utf-8')
 except:
+  #Python3
   rawtype = bytes
   raw2str = lambda r: r.decode('utf-8')
+  str2raw = lambda s: s.encode('utf-8')
+
 
 def ingest(d):
   if isinstance(d, rawtype):
@@ -25,7 +30,7 @@ def egest(s):
   if isinstance(s, rawtype):
     return s
   elif isinstance(s, str): # On python 2 str is bytes.
-    return s.encode('utf-8')
+    return str2raw(s)
   else:
     raise TypeError("Can't egest data of type %s" % type(s))
 

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -8,28 +8,31 @@ except ImportError:
 
 try:
   #Python2
-  rawtype = unicode
-  raw2str = lambda r: r.encode('utf-8')
+  rawtype = str
+  safetype = unicode
+  raw2str = lambda r: r.decode('utf-8')
   str2raw = lambda s: s.encode('utf-8')
 except:
   #Python3
   rawtype = bytes
+  safetype = str
   raw2str = lambda r: r.decode('utf-8')
   str2raw = lambda s: s.encode('utf-8')
 
-
 def ingest(d):
+  """Convert rawtype (str py27 or bytes py3x) to safetype (unicode py27 or str py3x)"""
   if isinstance(d, rawtype):
     return raw2str(d)
-  elif isinstance(d, str):
+  elif isinstance(d, safetype):
     return d
   else:
     raise TypeError("Can't ingest data of type %s" % type(d))
 
 def egest(s):
+  """Convert safetype (unicode py27, str py3x) to rawtype (str py27 or bytes py3x)"""
   if isinstance(s, rawtype):
     return s
-  elif isinstance(s, str): # On python 2 str is bytes.
+  elif isinstance(s, safetype): # On python 2 str is bytes.
     return str2raw(s)
   else:
     raise TypeError("Can't egest data of type %s" % type(s))

--- a/farmfs/volume.py
+++ b/farmfs/volume.py
@@ -121,7 +121,7 @@ class FarmFSVolume:
     try:
         with exclude_file.open('r') as exclude_fd:
           for pattern in exclude_fd.readlines():
-            pattern = str(Path(pattern.strip(), root))
+            pattern = ingest(Path(pattern.strip(), root))
             self.exclude.append(pattern)
     except IOError as e:
       if e.errno == NoSuchFile:

--- a/farmfs/volume.py
+++ b/farmfs/volume.py
@@ -45,28 +45,28 @@ def mkfs(root, udd):
   kdb = KeyDB(_keys_path(root))
   # Make sure root key is removed.
   kdb.delete("root")
-  kdb.write('udd', str(udd))
+  kdb.write('udd', safetype(udd))
   udd.mkdir()
   kdb.write('status', {})
   vol = FarmFSVolume(root)
 
-@returned(str)
-@typed(str, int, int)
+@returned(safetype)
+@typed(safetype, int, int)
 def _checksum_to_path(checksum, num_segs=3, seg_len=3):
   segs = [ checksum[i:i+seg_len] for i in range(0, min(len(checksum), seg_len * num_segs), seg_len)]
   segs.append(checksum[num_segs*seg_len:])
   return sep.join(segs)
 
 _sep_replace_ = re.compile(sep)
-@returned(str)
-@typed(str)
+@returned(safetype)
+@typed(safetype)
 def _remove_sep_(path):
     return _sep_replace_.subn("",path)[0]
 
 def reverser(num_segs=3):
   r = re.compile("((\/([0-9]|[a-f])+){%d})$" % (num_segs+1))
   def checksum_from_link(link):
-    m = r.search(str(link))
+    m = r.search(safetype(link))
     if (m):
       csum_slash = m.group()[1:]
       csum = _remove_sep_(csum_slash)
@@ -93,7 +93,7 @@ def directory_signatures(snap, root):
   return dirs
 
 def encode_volume(vol):
-  return str(vol.root)
+  return safetype(vol.root)
 
 def decode_volume(vol, key):
   return FarmFSVolume(Path(vol))
@@ -117,7 +117,7 @@ class FarmFSVolume:
     self.check_userdata_blob = compose(invert, partial(_validate_checksum, self.reverser))
 
     exclude_file = Path('.farmignore', self.root)
-    self.exclude = [str(self.mdd)]
+    self.exclude = [safetype(self.mdd)]
     try:
         with exclude_file.open('r') as exclude_fd:
           for pattern in exclude_fd.readlines():
@@ -235,7 +235,7 @@ class FarmFSVolume:
         if ud_path == udd_name:
           yield path
 
-  """ Yield all the relative paths (str) for all the files in the userdata store."""
+  """ Yield all the relative paths (safetype) for all the files in the userdata store."""
   def userdata_csums(self):
    # We populate counts with all hash paths from the userdata directory.
    for (path, type_) in self.udd.entries():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ test_requires = ['tox', 'pytest==4.6.8', 'tabulate']
 
 setup(
     name='farmfs',
-    version='0.3.0',
+    version='0.4.0',
     author='Andrew Thomson',
     author_email='athomsonguy@gmail.com',
     packages=['farmfs'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_generate_tests(metafunc):
         segments = ['a', 'b', '+']
     else:
         segments = ['a', '+']
-    csums = [u'1', u'2']
+    csums = ['1', '2']
     if 'segments' in metafunc.fixturenames:
         metafunc.parametrize("segments", segments)
     if 'csums' in metafunc.fixturenames:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_generate_tests(metafunc):
         segments = ['a', 'b', '+']
     else:
         segments = ['a', '+']
-    csums = ['1', '2']
+    csums = [u'1', u'2']
     if 'segments' in metafunc.fixturenames:
         metafunc.parametrize("segments", segments)
     if 'csums' in metafunc.fixturenames:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -44,3 +44,25 @@ def test_cmp():
   assert Path("/a/c") > Path("/a/b")
   assert Path("/a/2") < Path("/b/1")
   assert Path("/") < Path("/a")
+
+@pytest.mark.skip(reason="bugs not impacting development at moment.")
+def test_relative_to():
+  assert Path("/a/b").relative_to(Path("/")) == "a/b"
+  assert Path("/a/b").relative_to(Path("/a")) == "b"
+  assert Path("/a/b/c").relative_to(Path("/a")) == "b/c"
+  assert Path("/a/b/c").relative_to(Path("/a/b")) == "c"
+  assert Path("/a/b").relative_to(Path("/c")) == "../a/b"
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        (b'', u"d41d8cd98f00b204e9800998ecf8427e"),
+        (b'abc', u"900150983cd24fb0d6963f7d28e17f72"),
+        (b'\xea\x80\x80abcd\xde\xb4', u'b8c6dee81075e87d348522b146c95ae3'),
+        ],)
+def test_checksum_empty(tmp_path, input, expected):
+  tmp = Path(str(tmp_path))
+  fp = tmp.join("empty.txt")
+  with fp.open("wb") as fd:
+      fd.write(input)
+  assert fp.checksum() == expected

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,6 +1,6 @@
 from farmfs.fs import normpath as _normalize
 from farmfs.fs import userPath2Path as up2p
-from farmfs.fs import Path
+from farmfs.fs import Path, FileDoesNotExist
 import pytest
 
 def test_create_path():
@@ -66,3 +66,24 @@ def test_checksum_empty(tmp_path, input, expected):
   with fp.open("wb") as fd:
       fd.write(input)
   assert fp.checksum() == expected
+
+def test_create_dir(tmp_path):
+    a = Path(str(tmp_path)).join('a')
+    b = a.join('b')
+    assert a.isdir() == False
+    assert b.isdir() == False
+    # Cannot create with missing parents.
+    with pytest.raises(OSError) as e_info:
+      b.mkdir()
+    assert e_info.value.errno == FileDoesNotExist
+    assert a.isdir() == False
+    assert b.isdir() == False
+    # Create a
+    a.mkdir()
+    assert a.isdir() == True
+    assert b.isdir() == False
+    # idempotent
+    a.mkdir()
+    assert a.isdir() == True
+    assert b.isdir() == False
+

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -4,6 +4,7 @@ from farmfs.keydb import KeyDBFactory
 from farmfs.fs import Path
 from farmfs import cwd
 from farmfs.fs import ensure_absent
+from farmfs.util import safetype
 
 class KeyDBWrapper:
   def __init__(self, root):
@@ -51,12 +52,12 @@ def test_KeyDBFactory_same():
 def test_KeyDBFactory_diff():
   with KeyDBWrapper("./db") as db:
     window = KeyDBWindow("window", db)
-    factory = KeyDBFactory(window, str, lambda data, name : str(data))
+    factory = KeyDBFactory(window, str, lambda data, name : safetype(data))
     assert factory.list() == []
     factory.write("five", 5)
     assert factory.list() == ["five"]
     value = factory.read("five")
-    assert value == str(5)
+    assert value == safetype(5)
     factory.delete("five")
     assert factory.list() == []
 

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -6,6 +6,8 @@ from farmfs import cwd
 from farmfs.fs import ensure_absent
 from farmfs.util import safetype
 
+#TODO don't use cwd in sub-module.
+#TODO lets use temp file fixture.
 class KeyDBWrapper:
   def __init__(self, root):
     self.root = Path(root, cwd)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,35 @@
+import pytest
+from farmfs.fs import Path
+from farmfs.ui import farmfs_ui
+
+def test_farmfs_mkfs(tmp_path):
+    tmp = Path(str(tmp_path))
+    farmfs_ui(['mkfs'], tmp)
+    meta = Path(".farmfs", tmp)
+    assert meta.isdir()
+    userdata = Path("userdata", meta)
+    assert userdata.isdir()
+    snaps = Path("snaps", meta)
+    assert snaps.isdir()
+    keys = Path("keys", meta)
+    assert keys.isdir()
+
+def test_farmfs_freeze_thaw(tmp_path):
+    root = Path(str(tmp_path))
+    farmfs_ui(['mkfs'], root)
+    a = Path('a', root)
+    ab = Path('a/b', root)
+    a.mkdir()
+    with ab.open('w') as bfd:
+        bfd.write("hi")
+    assert a.isdir()
+    assert ab.isfile()
+    farmfs_ui(['freeze'], root)
+    assert a.isdir()
+    assert ab.islink()
+    hi_blob = ab.readlink()
+    userdata = Path('.farmfs/userdata', root)
+    assert userdata in list(hi_blob.parents())
+    with hi_blob.open('r') as hifd:
+        content = hifd.read()
+    assert content == "hi"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,7 +16,8 @@ def test_farmfs_mkfs(tmp_path):
 
 def test_farmfs_freeze_thaw(tmp_path):
     root = Path(str(tmp_path))
-    farmfs_ui(['mkfs'], root)
+    r1 = farmfs_ui(['mkfs'], root)
+    assert r1 == 0
     a = Path('a', root)
     ab = Path('a/b', root)
     a.mkdir()
@@ -24,12 +25,26 @@ def test_farmfs_freeze_thaw(tmp_path):
         bfd.write("hi")
     assert a.isdir()
     assert ab.isfile()
-    farmfs_ui(['freeze'], root)
+    r2 = farmfs_ui(['freeze'], root)
+    assert r2 == 0
     assert a.isdir()
     assert ab.islink()
     hi_blob = ab.readlink()
+    assert hi_blob.isfile()
     userdata = Path('.farmfs/userdata', root)
     assert userdata in list(hi_blob.parents())
     with hi_blob.open('r') as hifd:
         content = hifd.read()
     assert content == "hi"
+    r3 = farmfs_ui(['snap', 'make', 'mysnap'], root)
+    assert r3 == 0
+    snap = root.join(".farmfs/snap/mysnap")
+    snap.exists()
+    ab.unlink()
+    assert not ab.exists()
+    assert hi_blob.isfile()
+    r4 = farmfs_ui(['snap', 'restore', 'mysnap'], root)
+    assert r4 == 0
+    assert ab.islink()
+    assert hi_blob.isfile()
+    assert ab.readlink() == hi_blob

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -15,11 +15,11 @@ def test_farmfs_mkfs(tmp_path):
     assert keys.isdir()
 
 @pytest.mark.parametrize(
-    "parent,child",
+    "parent,child,snap",
     [
-        ("a", "b"),
+        ('a', 'b', 'mysnap'),
         ],)
-def test_farmfs_freeze_thaw(tmp_path, parent, child):
+def test_farmfs_freeze_thaw(tmp_path, parent, child, snap):
     root = Path(str(tmp_path))
     r1 = farmfs_ui(['mkfs'], root)
     assert r1 == 0
@@ -41,14 +41,14 @@ def test_farmfs_freeze_thaw(tmp_path, parent, child):
     with blob.open('r') as check_fd:
         content = check_fd.read()
     assert content == "hi"
-    r3 = farmfs_ui(['snap', 'make', 'mysnap'], root)
+    r3 = farmfs_ui(['snap', 'make', snap], root)
     assert r3 == 0
-    snap = root.join(".farmfs/snap/mysnap")
-    snap.exists()
+    snap_path = root.join(".farmfs/snap").join(snap)
+    snap_path.exists()
     child_path.unlink()
     assert not child_path.exists()
     assert blob.isfile()
-    r4 = farmfs_ui(['snap', 'restore', 'mysnap'], root)
+    r4 = farmfs_ui(['snap', 'restore', snap], root)
     assert r4 == 0
     assert child_path.islink()
     assert blob.isfile()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -53,3 +53,9 @@ def test_farmfs_freeze_thaw(tmp_path, parent, child, snap):
     assert child_path.islink()
     assert blob.isfile()
     assert child_path.readlink() == blob
+    r5 = farmfs_ui(['thaw', parent], root)
+    assert r5 == 0
+    assert child_path.isfile()
+    r6 = farmfs_ui(['freeze', child], parent_path)
+    assert r6 == 0
+    child_path.islink()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -14,37 +14,42 @@ def test_farmfs_mkfs(tmp_path):
     keys = Path("keys", meta)
     assert keys.isdir()
 
-def test_farmfs_freeze_thaw(tmp_path):
+@pytest.mark.parametrize(
+    "parent,child",
+    [
+        ("a", "b"),
+        ],)
+def test_farmfs_freeze_thaw(tmp_path, parent, child):
     root = Path(str(tmp_path))
     r1 = farmfs_ui(['mkfs'], root)
     assert r1 == 0
-    a = Path('a', root)
-    ab = Path('a/b', root)
-    a.mkdir()
-    with ab.open('w') as bfd:
-        bfd.write("hi")
-    assert a.isdir()
-    assert ab.isfile()
+    parent_path = Path(parent, root)
+    child_path = Path(child, parent_path)
+    parent_path.mkdir()
+    with child_path.open('w') as child_fd:
+        child_fd.write("hi")
+    assert parent_path.isdir()
+    assert child_path.isfile()
     r2 = farmfs_ui(['freeze'], root)
     assert r2 == 0
-    assert a.isdir()
-    assert ab.islink()
-    hi_blob = ab.readlink()
-    assert hi_blob.isfile()
+    assert parent_path.isdir()
+    assert child_path.islink()
+    blob = child_path.readlink()
+    assert blob.isfile()
     userdata = Path('.farmfs/userdata', root)
-    assert userdata in list(hi_blob.parents())
-    with hi_blob.open('r') as hifd:
-        content = hifd.read()
+    assert userdata in list(blob.parents())
+    with blob.open('r') as check_fd:
+        content = check_fd.read()
     assert content == "hi"
     r3 = farmfs_ui(['snap', 'make', 'mysnap'], root)
     assert r3 == 0
     snap = root.join(".farmfs/snap/mysnap")
     snap.exists()
-    ab.unlink()
-    assert not ab.exists()
-    assert hi_blob.isfile()
+    child_path.unlink()
+    assert not child_path.exists()
+    assert blob.isfile()
     r4 = farmfs_ui(['snap', 'restore', 'mysnap'], root)
     assert r4 == 0
-    assert ab.islink()
-    assert hi_blob.isfile()
-    assert ab.readlink() == hi_blob
+    assert child_path.islink()
+    assert blob.isfile()
+    assert child_path.readlink() == blob

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -15,11 +15,12 @@ def test_farmfs_mkfs(tmp_path):
     assert keys.isdir()
 
 @pytest.mark.parametrize(
-    "parent,child,snap",
+    "parent,child,snap,content",
     [
-        ('a', 'b', 'mysnap'),
+        ('a', 'b', 'mysnap', 'hi'),
+        (u'a', u'b', u'mysnap', u'hi'),
         ],)
-def test_farmfs_freeze_thaw(tmp_path, parent, child, snap):
+def test_farmfs_freeze_snap_thaw(tmp_path, parent, child, snap, content):
     root = Path(str(tmp_path))
     r1 = farmfs_ui(['mkfs'], root)
     assert r1 == 0
@@ -27,7 +28,7 @@ def test_farmfs_freeze_thaw(tmp_path, parent, child, snap):
     child_path = Path(child, parent_path)
     parent_path.mkdir()
     with child_path.open('w') as child_fd:
-        child_fd.write("hi")
+        child_fd.write(content)
     assert parent_path.isdir()
     assert child_path.isfile()
     r2 = farmfs_ui(['freeze'], root)
@@ -39,8 +40,8 @@ def test_farmfs_freeze_thaw(tmp_path, parent, child, snap):
     userdata = Path('.farmfs/userdata', root)
     assert userdata in list(blob.parents())
     with blob.open('r') as check_fd:
-        content = check_fd.read()
-    assert content == "hi"
+        check_content = check_fd.read()
+    assert check_content == content
     r3 = farmfs_ui(['snap', 'make', snap], root)
     assert r3 == 0
     snap_path = root.join(".farmfs/snap").join(snap)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 from farmfs.util import empty2dot, compose, concat, concatMap, fmap, identity, irange, invert, count, take, uniq, groupby, curry, uncurry, identify, pipeline, zipFrom
 import functools
 from collections import Iterator
-from farmfs.util import ingest, egest
+from farmfs.util import ingest, egest, safetype, rawtype
 import pytest
 
 try:
@@ -107,21 +107,21 @@ def test_zipFrom():
   assert list(zipFrom(1, [])) == []
 
 def test_ingest():
-    assert isinstance(ingest('abc'), str)
+    assert isinstance(ingest('abc'), safetype)
     assert ingest('abc') == 'abc'
-    assert isinstance(ingest(b'abc'), str)
+    assert isinstance(ingest(b'abc'), safetype)
     assert ingest(b'abc') == 'abc'
-    assert isinstance(ingest(u'abc'), str)
+    assert isinstance(ingest(u'abc'), safetype)
     assert ingest(u'abc') == 'abc'
     with pytest.raises(TypeError):
         assert ingest(5)
 
 def test_egest():
-    assert isinstance(egest('abc'), bytes)
+    assert isinstance(egest('abc'), rawtype)
     assert egest('abc') == b'abc'
-    assert isinstance(egest(b'abc'), bytes)
+    assert isinstance(egest(b'abc'), rawtype)
     assert egest(b'abc') == b'abc'
-    assert isinstance(egest(u'abc'), bytes)
+    assert isinstance(egest(u'abc'), rawtype)
     assert egest(u'abc') == b'abc'
     with pytest.raises(TypeError):
         assert egest(5)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,8 @@
 from farmfs.util import empty2dot, compose, concat, concatMap, fmap, identity, irange, invert, count, take, uniq, groupby, curry, uncurry, identify, pipeline, zipFrom
 import functools
 from collections import Iterator
+from farmfs.util import ingest, egest
+import pytest
 
 try:
     from itertools import ifilter
@@ -103,3 +105,35 @@ def test_pipeline():
 def test_zipFrom():
   assert list(zipFrom(1, [2,3,4])) == [(1,2), (1,3), (1,4)]
   assert list(zipFrom(1, [])) == []
+
+def test_ingest():
+    assert isinstance(ingest('abc'), str)
+    assert ingest('abc') == 'abc'
+    assert isinstance(ingest(b'abc'), str)
+    assert ingest(b'abc') == 'abc'
+    assert isinstance(ingest(u'abc'), str)
+    assert ingest(u'abc') == 'abc'
+    with pytest.raises(TypeError):
+        assert ingest(5)
+
+def test_egest():
+    assert isinstance(egest('abc'), bytes)
+    assert egest('abc') == b'abc'
+    assert isinstance(egest(b'abc'), bytes)
+    assert egest(b'abc') == b'abc'
+    assert isinstance(egest(u'abc'), bytes)
+    assert egest(u'abc') == b'abc'
+    with pytest.raises(TypeError):
+        assert egest(5)
+
+def test_ingest_egest():
+    byte_str = b'I\xc3\xb1t\xc3\xabrn\xc3\xa2ti\xc3\xb4n\xc3\xa0li\xc5\xbe\xc3\xa6ti\xc3\xb8n\n'
+    s = ingest(byte_str)
+    b = egest(s)
+    assert byte_str == b
+
+def test_egest_ingest():
+    tst_str = u'abc'
+    b = egest(tst_str)
+    s = ingest(b)
+    assert tst_str == s

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -6,6 +6,7 @@ from farmfs.fs import sep, ROOT, Path, LINK, DIR
 from tests.trees import makeLink
 import pytest
 from functools import reduce
+from farmfs.util import safetype
 
 def produce_mismatches(segments):
   """ Helper function to produce pairs of paths which have lexographical/path order mismatches"""
@@ -98,5 +99,5 @@ def test_tree_diff(trees):
         # assert(expected_removed_csums <= removed_csums)
         assert(expected_added_csums <= added_csums)
     except AssertionError as ae:
-        print("Conditions:", before, "->", after, "with changes", list(map(str, deltas)))
+        print("Conditions:", before, "->", after, "with changes", list(map(safetype, deltas)))
         raise

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -20,17 +20,17 @@ def test_mismatches_possible():
   assert len(produce_mismatches(letters)) > 0
 
 def test_tree_diff_order():
-  name_a =  "/a/+b"
-  name_b = "/a+/b"
+  name_a =  u"/a/+b"
+  name_b = u"/a+/b"
 
   path_a = Path(name_a)
   path_b = Path(name_b)
 
-  link_a = makeLink(name_a, "00000000000000000000000000000000")
-  link_b = makeLink(name_b, "00000000000000000000000000000000")
+  link_a = makeLink(path_a, u"00000000000000000000000000000000")
+  link_b = makeLink(path_b, u"00000000000000000000000000000000")
 
-  left  = KeySnapshot([link_a], "left",  None)
-  right = KeySnapshot([link_b], "right", None)
+  left  = KeySnapshot([link_a], u"left",  None)
+  right = KeySnapshot([link_b], u"right", None)
 
   diff = tree_diff(left, right)
   paths = list(map(lambda change: change.path(ROOT), diff))
@@ -73,8 +73,8 @@ def test_tree_diff(trees):
     expected_removed_csums = before_csums - after_csums
     expected_added_csums = after_csums - before_csums
 
-    beforeSnap = KeySnapshot(before, "before",  None)
-    afterSnap = KeySnapshot(after, "after", None)
+    beforeSnap = KeySnapshot(before, u"before",  None)
+    afterSnap = KeySnapshot(after, u"after", None)
     deltas = list(tree_diff(beforeSnap, afterSnap))
 
     removed = list(filter(lambda d: d.mode == d.REMOVED, deltas))

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from farmfs.volume import *
 from itertools import permutations, combinations, chain, product
 from  re import search
-from farmfs.fs import sep, ROOT, Path
+from farmfs.fs import sep, ROOT, Path, LINK, DIR
 from tests.trees import makeLink
 import pytest
 from functools import reduce
@@ -40,13 +40,13 @@ def test_tree(tree):
     try:
         assert len(tree)>=1
         assert tree[0]['path'] == ROOT
-        assert tree[0]['type'] == 'dir'
+        assert tree[0]['type'] == DIR
     except AssertionError as e:
         print("Bad tree:", tree)
         raise
 
 def tree_csums(tree):
-    links = filter(lambda t: t['type'] == 'link', tree)
+    links = filter(lambda t: t['type'] == LINK, tree)
     csums = set(map(lambda l: l['csum'], links))
     return csums
 
@@ -77,9 +77,9 @@ def test_tree_diff(trees):
     afterSnap = KeySnapshot(after, "after", None)
     deltas = list(tree_diff(beforeSnap, afterSnap))
 
-    removed = list(filter(lambda d: d.mode == 'removed', deltas))
+    removed = list(filter(lambda d: d.mode == d.REMOVED, deltas))
     removed_paths = set(map(lambda d: d.path(ROOT), removed))
-    added = list(filter(lambda d: d.mode != 'removed', deltas))
+    added = list(filter(lambda d: d.mode != d.REMOVED, deltas))
     added_paths = set(map(lambda d: d.path(ROOT), added))
     extra_removed_paths = removed_paths - expected_removed_paths
     try:

--- a/tests/trees.py
+++ b/tests/trees.py
@@ -80,5 +80,6 @@ def makeDir(path):
     return {"path": path, "type": DIR}
 
 def makeLink(path, csum):
+    assert isinstance(path, Path)
     return {"path": path, "csum": csum, "type": LINK}
 

--- a/tests/trees.py
+++ b/tests/trees.py
@@ -1,4 +1,4 @@
-from farmfs.fs import sep, ROOT, Path
+from farmfs.fs import sep, ROOT, Path, LINK, DIR
 from itertools import permutations, combinations, chain, product
 from collections import defaultdict
 
@@ -77,8 +77,8 @@ def makeDirectoryPermutations(paths):
     return defaultdict(list, dirs)
 
 def makeDir(path):
-    return {"path": path, "type": "dir"}
+    return {"path": path, "type": DIR}
 
 def makeLink(path, csum):
-    return {"path": path, "csum": csum, "type": "link"}
+    return {"path": path, "csum": csum, "type": LINK}
 


### PR DESCRIPTION
Safetype represents the type which handles unicode properly.
On py2x its unicode.
On py3x is str.

farmfs deals with bytes often, so we want to do all IO in terms of bytes, but do logic in terms of safetype. 