### PR TITLE
Missing csums ui added to farmdbg. 

### DIFF
--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -386,8 +386,9 @@ def dbg_ui(argv, cwd):
     snap = vol.snapdb.read(snapName)
     def missing_printr(csum, pathStrs):
         print("Missing csum %s with paths:" % csum)
-        for pathStr in pathStrs:
-            print("\t%s" % vol.root.join(pathStr).relative_to(cwd, leading_sep=False))
+        paths = sorted(imap(lambda pathStr: vol.root.join(pathStr), pathStrs))
+        for path in paths:
+            print("\t%s" % path.relative_to(cwd, leading_sep=False))
     missing_csum2pathStr = pipeline(
             partial(ifilter, lambda item: item.is_link()),
             partial(ifilter, lambda item: item.csum() not in tree_csums),

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -274,6 +274,7 @@ Usage:
   farmdbg checksum <path>...
   farmdbg fix link <file> <target>
   farmdbg rewrite-links <target>
+  farmdbg missing (tree|<snap>) <snaps>...
 """
 
 def dbg_main():
@@ -344,4 +345,6 @@ def dbg_ui(argv, cwd):
       new = vol.repair_link(link)
       if new is not None:
           print("Relinked %s to %s" % (link.relative_to(cwd, leading_sep=False), new))
+  elif args['missing']:
+    print(args['<snaps>'], args['<snap>'], args['tree'], )
   return exitcode

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -305,7 +305,7 @@ Usage:
   farmdbg checksum <path>...
   farmdbg fix link <file> <target>
   farmdbg rewrite-links <target>
-  farmdbg missing (tree|<snap>) <snaps>...
+  farmdbg missing <snap>
 """
 
 def dbg_main():
@@ -377,5 +377,23 @@ def dbg_ui(argv, cwd):
       if new is not None:
           print("Relinked %s to %s" % (link.relative_to(cwd, leading_sep=False), new))
   elif args['missing']:
-    print(args['<snaps>'], args['<snap>'], args['tree'], )
+    tree_csums = pipeline(
+            partial(ifilter, lambda item: item.is_link()),
+            fmap(lambda item: item.csum()),
+            set
+            )(iter(vol.tree()))
+    snapName = args['<snap>']
+    snap = vol.snapdb.read(snapName)
+    def missing_printr(csum, pathStrs):
+        print("Missing csum %s with paths:" % csum)
+        for pathStr in pathStrs:
+            print("\t%s" % vol.root.join(pathStr).relative_to(cwd, leading_sep=False))
+    missing_csum2pathStr = pipeline(
+            partial(ifilter, lambda item: item.is_link()),
+            partial(ifilter, lambda item: item.csum() not in tree_csums),
+            partial(groupby, lambda item: item.csum()),
+            fmap(uncurry(lambda csum, items: (csum, list(imap(lambda item: item.pathStr(), items))))),
+            fmap(uncurry(missing_printr)),
+            count
+            )(iter(snap))
   return exitcode

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -293,5 +293,5 @@ def test_missing(tmp_path, capsys):
     r = dbg_ui(['missing', 'snk'], root)
     captured = capsys.readouterr()
     assert r == 0
-    assert captured.out == "Missing csum 92eb5ffee6ae2fec3ad71c777531578f with paths:\n\tb\tb2"
+    assert captured.out == "Missing csum 92eb5ffee6ae2fec3ad71c777531578f with paths:\n\tb\n\tb2\n"
     assert captured.err == ""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -267,3 +267,31 @@ def test_gc(tmp_path, capsys):
     assert not sd_blob.exists()
     assert tk_blob.exists()
     assert not td_blob.exists()
+
+def test_missing(tmp_path, capsys):
+    root = Path(str(tmp_path))
+    a = Path('a', root)
+    b = Path('b', root)
+    b2 = Path('b2', root)
+    # Make the Farm
+    r = farmfs_ui(['mkfs'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    # Make a,b,b2; freeze, snap, delete
+    with a.open('w') as fd: fd.write('a')
+    with b.open('w') as fd: fd.write('b')
+    with b2.open('w') as fd: fd.write('b')
+    r = farmfs_ui(['freeze'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    r = farmfs_ui(['snap', 'make', 'snk'], root)
+    captured = capsys.readouterr()
+    # Remove b's
+    b.unlink()
+    b2.unlink()
+    # Look for missing checksum:
+    r = dbg_ui(['missing', 'snk'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    assert captured.out == "Missing csum 92eb5ffee6ae2fec3ad71c777531578f with paths:\n\tb\tb2"
+    assert captured.err == ""


### PR DESCRIPTION
We can now identify csums which are in a old snapshot, but not yet present in the tree. 