### PR TITLE
Repair aid

### DIFF
--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -175,6 +175,7 @@ class Path:
     assert isinstance(dst, Path)
     symlink(dst._path, self._path)
 
+  #TODO this behavior is the opposite of what one would expect.
   def copy(self, dst):
     assert isinstance(dst, Path)
     with open(self._path, 'rb') as src_fd:
@@ -383,13 +384,13 @@ def is_readonly(path):
   return bool(writable)
 
 @typed(Path, Path)
-def ensure_copy(path, orig):
-  assert orig.exists()
-  parent = path.parent()
-  assert parent != path, "Path and parent were the same!"
+def ensure_copy(dst, src):
+  assert src.exists()
+  parent = dst.parent()
+  assert parent != dst, "dst and parent were the same!"
   ensure_dir(parent)
-  ensure_absent(path)
-  orig.copy(path)
+  ensure_absent(dst)
+  src.copy(dst)
 
 @typed(Path, Path)
 def ensure_symlink(path, orig):

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -41,6 +41,8 @@ class XSym(Type):
                 mime='inode/symlink',
                 extension='xsym')
     def match(self, buf):
+        """Detects the MS-Dos symbolic link format from OSX.
+        Format of XSym files taken from section 11.7.3 of Mac OSX Internals"""
         return (len(buf) >= 10 and
                 buf[0] == 0x58 and # X
                 buf[1] == 0x53 and # S

--- a/farmfs/keydb.py
+++ b/farmfs/keydb.py
@@ -116,6 +116,7 @@ class KeyDBFactory():
   def delete(self, key):
     self.keydb.delete(key)
 
+  #TODO I don't think I used this.
   def copy(self, key, remote):
     value = remote.read(key)
     self.write(key, value)

--- a/farmfs/keydb.py
+++ b/farmfs/keydb.py
@@ -116,3 +116,6 @@ class KeyDBFactory():
   def delete(self, key):
     self.keydb.delete(key)
 
+  def copy(self, key, remote):
+    value = remote.read(key)
+    self.write(key, value)

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -25,6 +25,14 @@ def json_printr(data):
 
 strs_printr = pipeline(fmap(print), consume)
 
+def dict_printr(keys, d):
+    print("\t".join([str(d.get(k, '')) for k in keys]))
+
+def dicts_printr(keys):
+    return pipeline(fmap(partial(dict_printr, keys)), consume)
+
+snapshot_printr = dicts_printr(['path', 'type', 'csum'])
+
 UI_USAGE = \
 """
 FarmFS
@@ -353,9 +361,17 @@ def dbg_ui(argv, cwd):
       db.write(key, value)
   elif args['walk']:
     if args['root']:
-      json_printr(encode_snapshot(vol.tree()))
+      if args['--json']:
+        printr = json_printr
+      else:
+        printr = snapshot_printr
+      printr(encode_snapshot(vol.tree()))
     elif args['snap']:
-      json_printr(encode_snapshot(vol.snapdb.read(args['<snapshot>'])))
+      if args['--json']:
+        printr = json_printr
+      else:
+        printr = snapshot_printr
+      printr(encode_snapshot(vol.snapdb.read(args['<snapshot>'])))
     elif args['userdata']:
       if args['--json']:
         printr = json_printr

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -26,7 +26,7 @@ def json_printr(data):
 strs_printr = pipeline(fmap(print), consume)
 
 def dict_printr(keys, d):
-    print("\t".join([str(d.get(k, '')) for k in keys]))
+    print("\t".join([ingest(d.get(k, '')) for k in keys]))
 
 def dicts_printr(keys):
     return pipeline(fmap(partial(dict_printr, keys)), consume)

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -307,6 +307,7 @@ Usage:
   farmdbg rewrite-links <target>
   farmdbg missing <snap>
   farmdbg blobtype <blob>...
+  farmdbg blob <blob>...
 """
 
 def dbg_main():
@@ -414,4 +415,9 @@ def dbg_ui(argv, cwd):
       print(
               blob,
               maybe("unknown", vol.csum_to_path(blob).filetype()))
+  elif args['blob']:
+    for csum in args['<blob>']:
+      csum = ingest(csum)
+      print(csum,
+              vol.csum_to_path(csum).relative_to(cwd, leading_sep=False))
   return exitcode

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -5,7 +5,7 @@ from docopt import docopt
 from functools import partial
 from farmfs import cwd
 from farmfs.util import empty2dot, fmap, pipeline, concat, identify, uncurry, count, groupby, consume, concatMap, zipFrom, safetype, ingest, first, maybe, every
-from farmfs.volume import mkfs, tree_diff, tree_patcher, encode_snapshot
+from farmfs.volume import mkfs, tree_diff, tree_patcher, encode_snapshot, blob_import
 from farmfs.fs import Path, userPath2Path, ftype_selector, FILE, LINK, skip_ignored, is_readonly, ensure_symlink
 from json import JSONEncoder
 import sys
@@ -372,7 +372,7 @@ def dbg_ui(argv, cwd):
     if not bp.exists():
       print("blob %s doesn't exist" % b)
       if args['--remote']:
-        remote = vol.remotedb.read(args['<remote>'])
+        remote = vol.remotedb.read(args['--remote'])
       else:
         raise(ValueError("aborting due to missing blob"))
       rbp = remote.csum_to_path(b)

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -386,10 +386,9 @@ def dbg_ui(argv, cwd):
     snapName = args['<snap>']
     snap = vol.snapdb.read(snapName)
     def missing_printr(csum, pathStrs):
-        print("Missing csum %s with paths:" % csum)
         paths = sorted(imap(lambda pathStr: vol.root.join(pathStr), pathStrs))
         for path in paths:
-            print("\t%s" % path.relative_to(cwd, leading_sep=False))
+            print("%s\t%s" % (csum, path.relative_to(cwd, leading_sep=False)))
     missing_csum2pathStr = pipeline(
             partial(ifilter, lambda item: item.is_link()),
             partial(ifilter, lambda item: not vol.is_ignored(item.to_path(vol.root), None)),

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -303,7 +303,7 @@ Usage:
   farmdbg key list [<key>]
   farmdbg walk (keys|userdata|root|snap <snapshot>)
   farmdbg checksum <path>...
-  farmdbg fix link <target> <file>
+  farmdbg fix link [--remote=<remote>] <target> <file>
   farmdbg rewrite-links <target>
   farmdbg missing <snap>
   farmdbg blobtype <blob>...
@@ -370,7 +370,15 @@ def dbg_ui(argv, cwd):
     b = ingest(args['<target>'])
     bp = vol.csum_to_path(b)
     if not bp.exists():
-      raise ValueError("blob %s doesn't exist" % b)
+      print("blob %s doesn't exist" % b)
+      if args['--remote']:
+        remote = vol.remotedb.read(args['<remote>'])
+      else:
+        raise(ValueError("aborting due to missing blob"))
+      rbp = remote.csum_to_path(b)
+      blob_import(rbp, bp)
+    else:
+      pass #bp exists, can we check its checksum?
     ensure_symlink(f, bp)
   elif args['rewrite-links']:
     target = Path(args['<target>'], cwd)

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -369,7 +369,11 @@ def dbg_ui(argv, cwd):
               ) (walk([vol.udd], None, [FILE]))
       printr(userdata)
     elif args['keys']:
-      json_printr(vol.keydb.list())
+      if args['--json']:
+        printr = json_printr
+      else:
+        printr = strs_printr
+      printr(vol.keydb.list())
   elif args['checksum']:
     #TODO <checksum> <full path>
     paths = imap(lambda x: Path(x, cwd), empty2dot(args['<path>']))

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -361,23 +361,13 @@ def dbg_ui(argv, cwd):
       db.write(key, value)
   elif args['walk']:
     if args['root']:
-      if args['--json']:
-        printr = json_printr
-      else:
-        printr = snapshot_printr
+      printr = json_printr if args.get('--json') else snapshot_printr
       printr(encode_snapshot(vol.tree()))
     elif args['snap']:
-      if args['--json']:
-        printr = json_printr
-      else:
-        printr = snapshot_printr
+      printr = json_printr if args.get('--json') else snapshot_printr
       printr(encode_snapshot(vol.snapdb.read(args['<snapshot>'])))
     elif args['userdata']:
-      if args['--json']:
-        printr = json_printr
-      else:
-        printr = strs_printr
-
+      printr = json_printr if args.get('--json') else strs_printr
       userdata = pipeline(
               fmap(first),
               fmap(vol.reverser),
@@ -385,10 +375,7 @@ def dbg_ui(argv, cwd):
               ) (walk([vol.udd], None, [FILE]))
       printr(userdata)
     elif args['keys']:
-      if args['--json']:
-        printr = json_printr
-      else:
-        printr = strs_printr
+      printr = json_printr if args.get('--json') else strs_printr
       printr(vol.keydb.list())
   elif args['checksum']:
     #TODO <checksum> <full path>

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -20,6 +20,9 @@ except ImportError:
     # On python3 map is lazy.
     imap = map
 
+def json_printr(data):
+    print(JSONEncoder(ensure_ascii=False, sort_keys=True).encode(data))
+
 UI_USAGE = \
 """
 FarmFS
@@ -348,18 +351,18 @@ def dbg_ui(argv, cwd):
       db.write(key, value)
   elif args['walk']:
     if args['root']:
-      print(JSONEncoder(ensure_ascii=False, sort_keys=True).encode(encode_snapshot(vol.tree())))
+      json_printr(encode_snapshot(vol.tree()))
     elif args['snap']:
-      print(JSONEncoder(ensure_ascii=False, sort_keys=True).encode(encode_snapshot(vol.snapdb.read(args['<snapshot>']))))
+      json_printr(encode_snapshot(vol.snapdb.read(args['<snapshot>'])))
     elif args['userdata']:
       userdata = pipeline(
               fmap(first),
               fmap(vol.reverser),
               list
               ) (walk([vol.udd], None, [FILE]))
-      print(JSONEncoder(ensure_ascii=False, sort_keys=True).encode(userdata))
+      json_printr(userdata)
     elif args['keys']:
-      print(JSONEncoder(ensure_ascii=False, sort_keys=True).encode(vol.keydb.list()))
+      json_printr(vol.keydb.list())
   elif args['checksum']:
     #TODO <checksum> <full path>
     paths = imap(lambda x: Path(x, cwd), empty2dot(args['<path>']))

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -4,7 +4,7 @@ from farmfs import getvol
 from docopt import docopt
 from functools import partial
 from farmfs import cwd
-from farmfs.util import empty2dot, fmap, pipeline, concat, identify, uncurry, count, groupby, consume, concatMap, zipFrom, safetype, ingest, first, maybe
+from farmfs.util import empty2dot, fmap, pipeline, concat, identify, uncurry, count, groupby, consume, concatMap, zipFrom, safetype, ingest, first, maybe, every
 from farmfs.volume import mkfs, tree_diff, tree_patcher, encode_snapshot
 from farmfs.fs import Path, userPath2Path, ftype_selector, FILE, LINK, skip_ignored, is_readonly, ensure_symlink
 from json import JSONEncoder
@@ -395,6 +395,7 @@ def dbg_ui(argv, cwd):
             partial(ifilter, lambda item: not vol.is_ignored(item.to_path(vol.root), None)),
             partial(ifilter, lambda item: item.csum() not in tree_csums),
             partial(groupby, lambda item: item.csum()),
+            partial(ifilter, uncurry(lambda csum, items: every(lambda item: not item.to_path(vol.root).exists(), items))),
             fmap(uncurry(lambda csum, items: (csum, list(imap(lambda item: item.pathStr(), items))))),
             fmap(uncurry(missing_printr)),
             count

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -303,7 +303,7 @@ Usage:
   farmdbg key list [<key>]
   farmdbg walk (keys|userdata|root|snap <snapshot>)
   farmdbg checksum <path>...
-  farmdbg fix link <file> <target>
+  farmdbg fix link <target> <file>
   farmdbg rewrite-links <target>
   farmdbg missing <snap>
   farmdbg blobtype <blob>...

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -23,6 +23,8 @@ except ImportError:
 def json_printr(data):
     print(JSONEncoder(ensure_ascii=False, sort_keys=True).encode(data))
 
+strs_printr = pipeline(fmap(print), consume)
+
 UI_USAGE = \
 """
 FarmFS
@@ -304,7 +306,7 @@ Usage:
   farmdbg key write <key> <value>
   farmdbg key delete <key>
   farmdbg key list [<key>]
-  farmdbg walk (keys|userdata|root|snap <snapshot>)
+  farmdbg walk (keys|userdata|root|snap <snapshot>) [--json]
   farmdbg checksum <path>...
   farmdbg fix link [--remote=<remote>] <target> <file>
   farmdbg rewrite-links <target>
@@ -355,12 +357,17 @@ def dbg_ui(argv, cwd):
     elif args['snap']:
       json_printr(encode_snapshot(vol.snapdb.read(args['<snapshot>'])))
     elif args['userdata']:
+      if args['--json']:
+        printr = json_printr
+      else:
+        printr = strs_printr
+
       userdata = pipeline(
               fmap(first),
               fmap(vol.reverser),
               list
               ) (walk([vol.udd], None, [FILE]))
-      json_printr(userdata)
+      printr(userdata)
     elif args['keys']:
       json_printr(vol.keydb.list())
   elif args['checksum']:

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -172,3 +172,9 @@ def maybe(default, v):
         return v
     else:
         return default
+
+def every(predicate, coll):
+    for x in coll:
+        if not predicate(x):
+            return False
+    return True

--- a/farmfs/volume.py
+++ b/farmfs/volume.py
@@ -286,6 +286,8 @@ def noop():
     pass
 
 def blob_import(src_blob, dst_blob):
+  """Takes source and destination as Paths"""
+  # XXX Can't take csums because we don't know the segment format of remotes.
   if dst_blob.exists():
     return "Apply No need to copy blob, already exists"
   else:

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -63,3 +63,15 @@ def test_KeyDBFactory_diff():
     factory.delete("five")
     assert factory.list() == []
 
+def test_KeyDBFactory_copy():
+  with KeyDBWrapper("./db1") as db1:
+    window1 = KeyDBWindow("window", db1)
+    factory1 = KeyDBFactory(window1, str, lambda data, name : safetype(data))
+    assert factory1.list() == []
+    factory1.write("five", 5)
+    with KeyDBWrapper("./db2") as db2:
+      window2 = KeyDBWindow("other", db2)
+      factory2 = KeyDBFactory(window2, str, lambda data, name: safetype(data))
+      factory2.copy("five", window1)
+      value = factory2.read("five")
+      assert value == safetype(5)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -198,7 +198,7 @@ def test_farmdbg_reverse(tmp_path, capsys, a, b, c):
     r4 = dbg_ui(['walk', 'root'], root)
     captured = capsys.readouterr()
     assert r4 == 0
-    assert captured.out == '[{"path": "/", "type": "dir"}, {"csum": "' + a_csum + '", "path": "/'+a+'", "type": "link"}, {"path": "/'+b+'", "type": "dir"}, {"csum": "' + a_csum + '", "path": "/'+b+'/'+c+'", "type": "link"}]\n'
+    assert captured.out == "/\tdir\t\n/%s\tlink\t%s\n/%s\tdir\t\n/%s/%s\tlink\t%s\n" % (a, a_csum, b, b, c, a_csum)
     assert captured.err == ''
     r5 = dbg_ui(['walk', 'userdata'], root)
     captured = capsys.readouterr()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -327,6 +327,8 @@ def test_fix_link(tmp_path, capsys):
     root = Path(str(tmp_path))
     a = Path('a', root)
     b = Path('b', root)
+    c = Path('c', root)
+    cd = Path('c/d', root)
     # Make the Farm
     r = farmfs_ui(['mkfs'], root)
     captured = capsys.readouterr()
@@ -351,3 +353,17 @@ def test_fix_link(tmp_path, capsys):
     assert r == 0
     assert captured.err == ""
     assert captured.out == ""
+    # Try to fix a link to a missing target.
+    r = dbg_ui(['fix', 'link', 'c', '0cc175b9c0f1b6a831c399e269772661'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    assert captured.err == ""
+    assert captured.out == ""
+    assert a.readlink() == c.readlink()
+    # Try to fix a link to a missing target, in a dir which is blobked by a link
+    r = dbg_ui(['fix', 'link', 'c/d', '0cc175b9c0f1b6a831c399e269772661'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    assert captured.err == ""
+    assert captured.out == ""
+    assert a.readlink() == cd.readlink()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -203,7 +203,7 @@ def test_farmdbg_reverse(tmp_path, capsys, a, b, c):
     r5 = dbg_ui(['walk', 'userdata'], root)
     captured = capsys.readouterr()
     assert r5 == 0
-    assert captured.out == '["' + a_csum + '"]\n'
+    assert captured.out == a_csum + '\n'
     assert captured.err == ''
     r6 = dbg_ui(['reverse', a_csum], root)
     captured = capsys.readouterr()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -393,3 +393,24 @@ def test_fix_link(tmp_path, capsys):
     assert captured.err == ""
     assert captured.out == ""
     assert a.readlink() == cd.readlink()
+
+def test_blob(tmp_path, capsys):
+    root = Path(str(tmp_path))
+    a = Path('a', root)
+    b = Path('b', root)
+    # Make the Farm
+    r = farmfs_ui(['mkfs'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    # Make a,b,b2; freeze, snap, delete
+    with a.open('w') as fd: fd.write('a')
+    with b.open('w') as fd: fd.write('b')
+    r = farmfs_ui(['freeze'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    # get blob paths
+    r = dbg_ui(['blob', '0cc175b9c0f1b6a831c399e269772661', '92eb5ffee6ae2fec3ad71c777531578f'], root)
+    captured = capsys.readouterr()
+    assert r == 0
+    assert captured.out == "0cc175b9c0f1b6a831c399e269772661 .farmfs/userdata/0cc/175/b9c/0f1b6a831c399e269772661\n92eb5ffee6ae2fec3ad71c777531578f .farmfs/userdata/92e/b5f/fee/6ae2fec3ad71c777531578f\n"
+    assert captured.err == ""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -280,7 +280,7 @@ def test_missing(tmp_path, capsys):
     captured = capsys.readouterr()
     assert r == 0
     # Make a,b,b2; freeze, snap, delete
-    with a.open('w') as fd: fd.write('a')
+    with a.open('w') as fd: fd.write('a_masked') # Checksum for a_mask should not appear missing, as a exists.
     with b.open('w') as fd: fd.write('b')
     with b2.open('w') as fd: fd.write('b')
     with c.open('w') as fd: fd.write('c')
@@ -290,6 +290,8 @@ def test_missing(tmp_path, capsys):
     r = farmfs_ui(['snap', 'make', 'snk'], root)
     captured = capsys.readouterr()
     # Remove b's
+    a.unlink()
+    with a.open('w') as fd: fd.write('a')
     b.unlink()
     b2.unlink()
     c.unlink()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -300,7 +300,7 @@ def test_missing(tmp_path, capsys):
     captured = capsys.readouterr()
     assert r == 0
     assert captured.err == ""
-    assert captured.out == "Missing csum 92eb5ffee6ae2fec3ad71c777531578f with paths:\n\tb\n\tb2\n"
+    assert captured.out == "92eb5ffee6ae2fec3ad71c777531578f\tb\n92eb5ffee6ae2fec3ad71c777531578f\tb2\n"
 
 def test_blobtype(tmp_path, capsys):
     root = Path(str(tmp_path))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -340,7 +340,7 @@ def test_fix_link(tmp_path, capsys):
     captured = capsys.readouterr()
     assert r == 0
     # Check file type for a
-    r = dbg_ui(['fix', 'link', 'b', '0cc175b9c0f1b6a831c399e269772661'], root)
+    r = dbg_ui(['fix', 'link', '0cc175b9c0f1b6a831c399e269772661', 'b'], root)
     captured = capsys.readouterr()
     assert r == 0
     assert captured.err == ""
@@ -348,20 +348,20 @@ def test_fix_link(tmp_path, capsys):
     assert a.readlink() == b.readlink()
     # Try to fix link to a missing blob.
     with pytest.raises(ValueError):
-        r = dbg_ui(['fix', 'link', 'b', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'], root)
+        r = dbg_ui(['fix', 'link', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'b'], root)
     captured = capsys.readouterr()
     assert r == 0
     assert captured.err == ""
     assert captured.out == ""
     # Try to fix a link to a missing target.
-    r = dbg_ui(['fix', 'link', 'c', '0cc175b9c0f1b6a831c399e269772661'], root)
+    r = dbg_ui(['fix', 'link', '0cc175b9c0f1b6a831c399e269772661', 'c'], root)
     captured = capsys.readouterr()
     assert r == 0
     assert captured.err == ""
     assert captured.out == ""
     assert a.readlink() == c.readlink()
     # Try to fix a link to a missing target, in a dir which is blobked by a link
-    r = dbg_ui(['fix', 'link', 'c/d', '0cc175b9c0f1b6a831c399e269772661'], root)
+    r = dbg_ui(['fix', 'link', '0cc175b9c0f1b6a831c399e269772661', 'c/d'], root)
     captured = capsys.readouterr()
     assert r == 0
     assert captured.err == ""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -354,7 +354,7 @@ def test_fix_link(tmp_path, capsys):
     captured = capsys.readouterr()
     assert r == 0
     assert captured.err == ""
-    assert captured.out == ""
+    assert captured.out == "blob aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa doesn't exist\n"
     # Try to fix a link to a missing target.
     r = dbg_ui(['fix', 'link', '0cc175b9c0f1b6a831c399e269772661', 'c'], root)
     captured = capsys.readouterr()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -255,11 +255,21 @@ def test_gc(tmp_path, capsys):
     td_blob = td.readlink()
     td_csum = str(td.checksum())
     td.unlink()
-    # GC
+    # GC --noop
     assert sk_blob.exists()
     assert sd_blob.exists()
     assert tk_blob.exists()
     assert td_blob.exists()
+    r = farmfs_ui(['gc', '--noop'], root)
+    captured = capsys.readouterr()
+    assert captured.out == 'Removing '+sd_csum+'\nRemoving '+td_csum+'\n'
+    assert captured.err == ''
+    assert r == 0
+    assert sk_blob.exists()
+    assert sd_blob.exists()
+    assert tk_blob.exists()
+    assert td_blob.exists()
+    # GC
     r = farmfs_ui(['gc'], root)
     captured = capsys.readouterr()
     assert captured.out == 'Removing '+sd_csum+'\nRemoving '+td_csum+'\n'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 import sys
-from farmfs.util import empty2dot, compose, concat, concatMap, fmap, identity, irange, invert, count, take, uniq, groupby, curry, uncurry, identify, pipeline, zipFrom, dot, nth, first, second
+from farmfs.util import empty2dot, compose, concat, concatMap, fmap, identity, irange, invert, count, take, uniq, groupby, curry, uncurry, identify, pipeline, zipFrom, dot, nth, first, second, every
 import functools
 from collections import Iterator
 from farmfs.util import ingest, egest, safetype, rawtype
@@ -155,3 +155,8 @@ def test_nth():
     assert nth(1)(lst) == 2
     assert first(lst) == 1
     assert second(lst) == 2
+
+def test_every():
+    assert every(even, [2,4,6])
+    assert not every(even, [2,3,4])
+    assert every(even, [])


### PR DESCRIPTION
Output for most farmdbg repair commands can now be in json format or unix format. This helps in building 1-liners to fix corruptions. 