### PR TITLE
Verify s3 checksums

### DIFF
--- a/farmfs/blobstore.py
+++ b/farmfs/blobstore.py
@@ -2,7 +2,7 @@ from farmfs.fs import Path, ensure_link, ensure_readonly, ensure_symlink, ensure
 from func_prototypes import typed, returned
 from farmfs.util import safetype, pipeline, fmap, first, compose, invert, partial, repeater
 from os.path import sep
-from s3lib import Connection as s3conn
+from s3lib import Connection as s3conn, LIST_BUCKET_KEY
 import re
 
 _sep_replace_ = re.compile(sep)
@@ -123,6 +123,17 @@ class S3Blobstore:
                 for key in key_iter:
                     blob = key[len(self.prefix)+1:]
                     yield blob
+        return blob_iterator
+
+    def blob_stats(self):
+        """Iterator across all blobs, retaining the listing information"""
+        def blob_iterator():
+            with s3conn(self.access_id, self.secret) as s3:
+                key_iter = s3.list_bucket2(self.bucket, prefix=self.prefix+"/")
+                for head in key_iter:
+                    blob = head[LIST_BUCKET_KEY][len(self.prefix)+1:]
+                    head['blob'] = blob
+                    yield head
         return blob_iterator
 
     def read_handle(self):

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -308,6 +308,7 @@ Usage:
   farmdbg blob <blob>...
   farmdbg s3 list <bucket> <prefix>
   farmdbg s3 upload [--quiet] <bucket> <prefix>
+  farmdbg s3 check <bucket> <prefix>
 """
 
 def dbg_main():
@@ -467,4 +468,14 @@ def dbg_ui(argv, cwd):
           else:
               print("Failed to upload")
               exitcode = 1
+      elif args['check']:
+        num_corrupt_blobs = pipeline(
+                ffilter(lambda obj: obj['ETag'][1:-1] != obj['blob']),
+                fmap(identify(lambda obj: print(obj['blob'], obj['ETag'][1:-1]))),
+                count
+                )(s3bs.blob_stats()())
+        if num_corrupt_blobs == 0:
+            print("All S3 blobs etags match")
+        else:
+            exitcode = 2
   return exitcode


### PR DESCRIPTION
S3 ETAG is based on MD5 checksum. FarmFS blob IDs are based on MD5 checksums. So we can use S3 list API to verify that blobs were uploaded correctly.