### PR TITLE
Enable KeyboardInterrupt in pfmap parallel workloads.

### DIFF
--- a/farmfs/blobstore.py
+++ b/farmfs/blobstore.py
@@ -157,6 +157,7 @@ class S3Blobstore:
             with path.open('rb') as f:
                 with s3conn(self.access_id, self.secret) as s3:
                     #TODO should provide pre-calculated md5 rather than recompute.
+                    #TODO put_object doesn't have a work cancellation feature.
                     result = s3.put_object(self.bucket, key, f)
             return result
         http_success = lambda status_headers: status_headers[0] >=200 and status_headers[0] < 300

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -290,6 +290,7 @@ class Path:
     with self.open('rb') as fd:
       buf = fd.read(_BLOCKSIZE)
       while len(buf) > 0:
+        # TODO Could cancel work here.
         hasher.update(buf)
         buf = fd.read(_BLOCKSIZE)
       digest = safetype(hasher.hexdigest())

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -73,17 +73,17 @@ def fmap(func):
 if sys.version_info >= (3, 0):
     def pfmap(func, workers=8):
         def parallel_mapped(collection):
-            try:
-                with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+                try:
                     # Enqueue all work from collection.
                     # XXX this is greedy, so we fully consume the input before starting to produce output.
                     for result in executor.map(func, collection):
                         yield result
-            except KeyboardInterrupt as e:
-                print("Caught keyboard interrupt, shutting down.")
-                executor.shutdown(wait=False, cancel_futures=True)
-                print("Threadpool shutdown completed.")
-                raise e
+                except KeyboardInterrupt as e:
+                    print("Caught keyboard interrupt, shutting down.")
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    print("Threadpool shutdown completed.")
+                    raise e
         return parallel_mapped
 else:
     def pfmap(func, workers=8):

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -83,6 +83,9 @@ if sys.version_info >= (3, 0):
                     print("Caught keyboard interrupt, shutting down.")
                     executor.shutdown(wait=False)
                     print("Threadpool shutdown completed.")
+                    executor._threads.clear()
+                    concurrent.futures.thread._threads_queues.clear()
+                    print("ungracefully shutdown thread pools.")
                     raise e
         return parallel_mapped
 else:

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -75,13 +75,9 @@ if sys.version_info >= (3, 0):
         def parallel_mapped(collection):
             with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
                 # Enqueue all work from collection.
-                # TODO this is greedy, so we fully consume the input before starting to produce output.
-                not_done = [executor.submit(func, i) for i in collection]
-                # Consume all work from queue
-                while len(not_done) > 0:
-                    (done, not_done) = concurrent.futures.wait(not_done, timeout=None, return_when=concurrent.futures.FIRST_COMPLETED)
-                    for future in done:
-                        yield future.result()
+                # XXX this is greedy, so we fully consume the input before starting to produce output.
+                for result in executor.map(func, collection):
+                    yield result
         return parallel_mapped
 else:
     def pfmap(func, workers=8):

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -73,11 +73,17 @@ def fmap(func):
 if sys.version_info >= (3, 0):
     def pfmap(func, workers=8):
         def parallel_mapped(collection):
-            with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-                # Enqueue all work from collection.
-                # XXX this is greedy, so we fully consume the input before starting to produce output.
-                for result in executor.map(func, collection):
-                    yield result
+            try:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+                    # Enqueue all work from collection.
+                    # XXX this is greedy, so we fully consume the input before starting to produce output.
+                    for result in executor.map(func, collection):
+                        yield result
+            except KeyboardInterrupt as e:
+                print("Caught keyboard interrupt, shutting down.")
+                executor.shutdown(wait=False, cancel_futures=True)
+                print("Threadpool shutdown completed.")
+                raise e
         return parallel_mapped
 else:
     def pfmap(func, workers=8):

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -81,7 +81,7 @@ if sys.version_info >= (3, 0):
                         yield result
                 except KeyboardInterrupt as e:
                     print("Caught keyboard interrupt, shutting down.")
-                    executor.shutdown(wait=False, cancel_futures=True)
+                    executor.shutdown(wait=False)
                     print("Threadpool shutdown completed.")
                     raise e
         return parallel_mapped

--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -80,12 +80,9 @@ if sys.version_info >= (3, 0):
                     for result in executor.map(func, collection):
                         yield result
                 except KeyboardInterrupt as e:
-                    print("Caught keyboard interrupt, shutting down.")
                     executor.shutdown(wait=False)
-                    print("Threadpool shutdown completed.")
                     executor._threads.clear()
                     concurrent.futures.thread._threads_queues.clear()
-                    print("ungracefully shutdown thread pools.")
                     raise e
         return parallel_mapped
 else:


### PR DESCRIPTION
ThreadPoolExecutor is swallowing KeyboardInterrupt because the wait to upload to S3 is really long.
Lets proactively cancel that work when we get a KeyboardInterrupt.