### PR TITLE
    Update fsck --cache test to verify end-to-end fix

### DIFF
--- a/farmfs/util.py
+++ b/farmfs/util.py
@@ -419,7 +419,9 @@ def csum_pct(csum):
     Takes a hex md5 checksum digest string. Returns a float between 0.0 and 1.0 representing what
     lexographic percentile of the checksum.
     """
-    assert len(csum) == 32
+    assert len(csum) == 32, (
+        f"Invalid checksum length: {len(csum)} (expected 32), value: {csum}"
+    )
     max_value = int("f" * 32, 16)
     csum_int = int(csum, 16)
     return csum_int / max_value
@@ -441,3 +443,32 @@ def cardinality(seen, pct):
     if pct < 0.00001:
         pct = 0.00001
     return int(seen / pct)
+
+
+def ordered_merge_diff(left_iter, right_iter):
+    """
+    Compare two sorted iterables incrementally, yielding (side, item) tuples.
+    side is "left" if item only in left, "right" if only in right.
+    Assumes both iterables are sorted in the same order.
+    Yields nothing for items present in both.
+    """
+    left = next(left_iter, None)
+    right = next(right_iter, None)
+
+    while left is not None or right is not None:
+        if left is not None and right is not None:
+            if left < right:
+                yield ("left", left)
+                left = next(left_iter, None)
+            elif left > right:
+                yield ("right", right)
+                right = next(right_iter, None)
+            else:  # left == right
+                left = next(left_iter, None)
+                right = next(right_iter, None)
+        elif left is not None:
+            yield ("left", left)
+            left = next(left_iter, None)
+        else:  # right is not None
+            yield ("right", right)
+            right = next(right_iter, None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,8 @@ def test_api_blob_list_full(vol, client):
     # Empty Depot
     response = client.get("/bs")
     assert response.status_code == 200
-    assert list(sorted([bloba, blobb, blobc])) == response.json
+    for blob in [bloba, blobb, blobc]:
+        assert blob in response.json
 
 
 def test_api_blob_create_no_id(vol, client):


### PR DESCRIPTION
    Test now:
    1. Creates a broken cache state with stale and missing entries
    2. Runs fsck --cache to detect issues
    3. Runs fsck --cache --fix to repair the cache
    4. Runs fsck --cache again to verify no issues remain

    This validates the complete fsck --cache workflow with our fixes.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit bc178e3085d1d489a36bde45b0b94ab3130113e9
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sun Nov 16 14:21:24 2025 -0800

    Fix fsck_cache_printr to preserve (side, blob) tuple for fixer

    fsck_cache_printr was only returning the blob, losing the side information
    needed by the fixer to determine whether to INSERT (right/store-only) or
    DELETE (left/cache-only).

    Now returns the full (side, blob) tuple so the fixer receives the complete
    information needed to persist changes to the cache.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit e81faa6eef720757ef5ba3879fd95bb229d91a94
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sun Nov 16 14:12:00 2025 -0800

    Add test to verify fsck --cache diff structure

    Test verifies:
    1. Diff structure is (side, blob) tuples
    2. "left" (cache-only) blobs should be deleted
    3. "right" (store-only) blobs should be added
    4. Matching blobs don't appear in diffs

    This validates that our fix correctly interprets the cache vs store
    diff results.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit 9129328d855f2b37e36f4c5e5477082101872fe4
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sun Nov 16 13:27:36 2025 -0800

    Fix backwards add/remove logic in fsck --cache

    The cache fsck was comparing cache blobs (left) against store blobs (right),
    but had the add/remove operations backwards:
    - Blobs only in cache (left) should be DELETED as stale entries
    - Blobs only in store (right) should be ADDED to the cache

    Fixed both the printer messages and the fixer transactor to correctly
    handle these cases.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit 0af854b2db0e318621159e68d92e007211ae19a2
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 23:23:43 2025 -0800

    try to fix cardinality calculation on farmfs fsck --cache

commit 1526bdbfadc886248bb0cc31f0f5c5af6fd67384
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 13:47:28 2025 -0800

    Add invalid checksum value to assertion error message in csum_pct()

    When a corrupted checksum is encountered (wrong length), the assertion now
    includes the actual invalid value and its length in the error message. This
    improves debugging when corrupted checksums are discovered in the cache database.

    Example error output:
      AssertionError: Invalid checksum length: 56 (expected 32), value: 0023ab8040e977d579978e193a2c977ee2248706cd5d5af9d2')]

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit 17fa4370b8cf6fbe39fe0aa2fd6cc470b131923f
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 02:20:55 2025 -0800

    Optimize exists() query for better performance

    - Change from SELECT * to SELECT 1 (constant literal)
    - More efficient: avoids selecting blob column unnecessarily
    - Clearer intent: explicitly selecting for existence check
    - Use 'is not None' for explicit boolean conversion
    - PRIMARY KEY ensures index usage on both queries

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit 0b2ed7c3f36202619aded9c279c92641c7cea72f
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 02:17:04 2025 -0800

    Simplify import operations to avoid stale checks

    - Restructure import_via_link() and import_via_fd() to check-and-skip pattern
    - If not forcing and cache says blob exists, return early
    - Otherwise, do the import and cache insert
    - Use INSERT OR REPLACE as safety net for concurrent operations
    - Document that duplicate return value may be stale
    - Future blobstore-level locking will handle strict consistency

    This approach avoids complex transaction logic while remaining safe:
    - INSERT OR REPLACE prevents PRIMARY KEY violations
    - Early return optimizes the common case (blob already cached)
    - Minimal race window between check and import

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit d8667eb277a6048aced686840766000fe43b186e
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 01:02:44 2025 -0800

    Address PR feedback: improve cache implementation

    - Add PRIMARY KEY constraint to blob column for data integrity
    - Use contextlib.closing() consistently for all cursor operations
    - Add force=False parameter to import_via_link() for API consistency
    - Wrap delete_blob() in transaction for atomic cache/store operations
    - Use INSERT OR REPLACE to handle duplicate insertions
    - Remove unused _synchronize_blobs() and synchronize_blobs() methods

    All operations now properly manage cursor lifecycle and maintain
    cache consistency through atomic transactions.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit c9c6248e5ba396eaf1e91cc6db4ca096ebd08a49
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 00:27:23 2025 -0800

    Format test_ui.py with consistent quote style

commit cb609eb53924fc282afb27c1e565527ce7ae2d11
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Sat Nov 15 00:23:58 2025 -0800

    Improve cache abstraction with check_below parameter

    - Add check_below parameter to CacheBlobstore.exists()
      - check_below=False (default): check cache layer only (fast)
      - check_below=True: check underlying store layer
    - Semantics reflect layered architecture: "check below me"
    - Removes need to reach down to vol.bs.store in fsck_missing_blobs
    - Use contextlib.closing() for proper cursor lifecycle management
    - Clarifies intent: cache is transparent optimization, not truth

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit b1ec2fb6318147decac3e91821c66379bb7ad2eb
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Fri Nov 14 23:18:54 2025 -0800

    Implement cache invalidation for blob index

    - Remove eager synchronize_blobs() from volume init (was O(num_blobs))
    - Add transaction() method to CacheBlobstore for atomic operations
    - Add ordered_merge_diff() utility for incremental sorted set comparison
    - Implement fsck --cache to validate and fix cache inconsistencies
      - Detects missing blobs (in store but not cache)
      - Detects stale entries (in cache but not store) - Fixes applied atomically in single transaction
    - Fix fsck --missing to check underlying blobstore, not cache
    - Fix fsck --missing --fix to force re-import when blob is corrupt
    - Ensure CacheBlobstore.blobs() returns sorted results via ORDER BY

    Cache is now self-maintaining for normal operations and can be
    validated/fixed on-demand via fsck --cache.

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>

commit c2e473661684804d5642bc02554c1fe3a8a18dd6
Merge: 9be7764 9d4649f
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Fri Nov 14 09:28:34 2025 -0800

    Merge branch 'master' into blob_index

commit 9be7764fa2e60292b97db0fd81970ad37168eb3b
Merge: e401431 5bd7418
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Mon Sep 1 23:52:17 2025 -0700

    Merge branch 'master' into blob_index

commit e4014318811d6270991fe1b1b81dd57d6612652f
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Fri May 16 15:55:27 2025 -0700

    got unit tests working, but disabled parallel download.

commit e338d2ab6cc8ca9786c36bbdb9f00b7aa223ae0f
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Fri May 16 14:13:51 2025 -0700

    migrate CacheBlobstore to modern Blobstore shape.

commit d94dbe6c81a9f7cd0b57d8f8c1b8b0d518ffe031
Merge: 0d60918 ea80935
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Fri May 16 08:33:51 2025 -0700

    Merge branch 'master' into blob_index

commit 0d609188e6886c6ebfb6c382ccc9eb3aa48937b1
Merge: 8733987 9ef411f
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Tue Jan 16 00:46:35 2024 -0800

    Merge branch 'master' into blob_index

commit 8733987e59baa32c7fb8daa6ff24619678b885fe
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Tue Jul 4 22:59:27 2023 -0700

    Adding py39 to build.

commit 442990fda2f5e7f4d529a1e462159a7be4056cfb
Author: Andrew Thomson <athomsonguy@gmail.com>
Date:   Tue Jul 4 22:58:43 2023 -0700

    Add test implementation of sqlite3 cache for blobstore lookups.