### PR TITLE
Add cursor-based paging to GET /bs

### DIFF
--- a/farmfs/api.py
+++ b/farmfs/api.py
@@ -3,6 +3,7 @@ from flask.typing import ResponseReturnValue
 from farmfs import getvol, cwd
 from farmfs.fs import Path
 from docopt import docopt
+from typing import Optional
 
 from farmfs.volume import FarmFSVolume
 
@@ -80,11 +81,27 @@ def get_app(args: dict[str, str]) -> Flask:
     @app.route("/bs", methods=["GET"])
     def blob_list() -> ResponseReturnValue:
         """
-        List all the blobs in the blobstore.
+        List blobs in the blobstore, with optional cursor-based paging.
+
+        Query params:
+          start-after=<blob>  Return blobs strictly after this checksum (exclusive).
+          max_items=<n>       Maximum number of blobs to return per page.
+
+        Response JSON:
+          {"blobs": [...], "next": "<blob>" | null}
+          "next" is the last blob on this page; pass it as "start-after" for
+          the next page. null when this is the last page.
         """
         vol = g.vol
         bs = vol.bs
-        return jsonify(list(bs.blobs())), 200
+        start_after = request.args.get("start-after", None)
+        max_items_str = request.args.get("max_items", None)
+        max_items = int(max_items_str) if max_items_str is not None else None
+
+        page = list(bs.blobs(start_after=start_after, max_items=max_items))
+        next_cursor: Optional[str] = page[-1] if (max_items is not None and len(page) == max_items) else None
+
+        return jsonify({"blobs": page, "next": next_cursor}), 200
 
     def blob_exists(blob) -> ResponseReturnValue:
         """

--- a/farmfs/blobstore.py
+++ b/farmfs/blobstore.py
@@ -9,6 +9,7 @@ from farmfs.fs import (
     is_readonly,
     is_user_readable,
     walk,
+    walk_from,
     walk_path,
 )
 import http.client
@@ -19,7 +20,7 @@ from contextlib import contextmanager
 from collections.abc import Callable
 from os.path import sep
 import re
-from typing import ContextManager, IO, Generator, Iterator, Optional, Tuple
+from typing import ContextManager, IO, Generator, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse
 from s3lib import Connection as s3conn, ConnectionLifecycleError, LIST_BUCKET_KEY
 from farmfs.util import (
@@ -213,15 +214,34 @@ class FileBlobstore:
         """
         return FileBlobstoreSession(self.root, self.tmp_dir)
 
-    def blobs(self) -> Iterator[str]:
-        """Iterator across all blobs"""
+    def blobs(self, start_after: Optional[str] = None, max_items: Optional[int] = None) -> Iterator[str]:
+        """Iterator across all blobs in sorted order.
+
+        start_after -- if given, return only blobs strictly after this checksum
+                       (exclusive, matching S3 semantics). Seeks directly into
+                       the right directory subtree via walk_from() then skips
+                       the start_after blob itself if present.
+        max_items   -- if given, return at most this many blobs.
+        """
+        import itertools
         keep_files = ftype_selector([FILE])
+
+        if start_after is not None:
+            walker = walk_from(self.root, self.blob_path(start_after))
+        else:
+            walker = walk(self.root)
 
         blobs: Iterator[str] = pipeline(
             keep_files,
             fmap(walk_path),
             fmap(self.reverser),
-        )(walk(self.root))
+        )(walker)
+
+        if start_after is not None:
+            # walk_from is inclusive; skip the start_after blob itself.
+            blobs = itertools.dropwhile(lambda b: b == start_after, blobs)
+        if max_items is not None:
+            blobs = itertools.islice(blobs, max_items)
         return blobs
 
     def read_handle(self, blob: str) -> IO[bytes]:
@@ -381,13 +401,27 @@ class S3Blobstore:
         """
         return S3BlobstoreSession(self.access_id, self.secret, self.bucket, self.prefix)
 
-    def blobs(self) -> Generator[str, None, None]:
-        """Iterator across all blobs"""
+    def blobs(self, start_after: Optional[str] = None, max_items: Optional[int] = None) -> Generator[str, None, None]:
+        """Iterator across all blobs in sorted order.
+
+        start_after -- if given, return only blobs strictly after this checksum
+                       (exclusive, matching S3 semantics). Passed directly to
+                       s3lib as start_after on the S3 key.
+        max_items   -- if given, return at most this many blobs.
+        """
+        s3_start_after: Optional[str] = None
+        if start_after is not None:
+            s3_start_after = self.prefix + "/" + start_after
+
         with s3conn(self.access_id, self.secret) as s3:
-            key_iter = s3.list_bucket(self.bucket, prefix=self.prefix + "/")
+            key_iter = s3.list_bucket(self.bucket, prefix=self.prefix + "/", start=s3_start_after, batch_size=max_items)
+            count = 0
             for key in key_iter:
                 blob = key[len(self.prefix) + 1:]
                 yield blob
+                count += 1
+                if max_items is not None and count >= max_items:
+                    break
 
     # TODO dict is rather open ended.
     def blob_stats(self) -> Callable[[], Generator[dict, None, None]]:
@@ -516,16 +550,32 @@ class HttpBlobstore:
         """
         return HttpBlobstoreSession(self.host, self.port, self.conn_timeout)
 
-    def blobs(self) -> Iterator[str]:
-        """Iterator across all blobs."""
-        with self._request("GET", "/bs") as resp:
-            # TODO raise on error?
-            if resp.status != http.client.OK:
-                # TODO RuntimeError is the python runtime error type, we need a blobstore specific error type.
-                raise RuntimeError(f"blobstore returned status code: {resp.status}")
-            list_str = resp.read()
-        blobs = json.loads(list_str)
-        return iter(blobs)
+    def blobs(self, start_after: Optional[str] = None, max_items: Optional[int] = None) -> Iterator[str]:
+        """Iterator across all blobs, fetching pages until exhausted.
+
+        start_after -- if given, return only blobs strictly after this checksum
+                       (exclusive, matching S3 semantics).
+        max_items   -- if given, return at most this many blobs in a single page.
+                       Without max_items, all pages are fetched and concatenated.
+        """
+        result: List[str] = []
+        cursor: Optional[str] = start_after
+        page_size = max_items if max_items is not None else 1000
+        while True:
+            params = f"max_items={page_size}"
+            if cursor is not None:
+                params += f"&start-after={cursor}"
+            with self._request("GET", f"/bs?{params}") as resp:
+                if resp.status != http.client.OK:
+                    raise RuntimeError(f"blobstore returned status code: {resp.status}")
+                payload = json.loads(resp.read())
+            result.extend(payload["blobs"])
+            if max_items is not None:
+                break
+            cursor = payload["next"]
+            if cursor is None:
+                break
+        return iter(result)
 
     def blob_checksum(self, blob: str) -> str:
         with self._request("GET", f"/bs/{blob}/checksum") as resp:

--- a/farmfs/fs.py
+++ b/farmfs/fs.py
@@ -731,6 +731,72 @@ def walk(
                 children = curPath.dir_list()
                 dirs.append(iter(children))
 
+def walk_from(
+        root: Path,
+        start: Path,
+) -> Generator[WalkItem, None, None]:
+    """Like walk(root), but begins at 'start' (inclusive) instead of the root.
+
+    'start' must be root or a descendant of root. The walk yields items in the
+    same sorted order as walk(), skipping directory subtrees that sort entirely
+    before 'start'.
+
+    At each directory level the children are partitioned by the corresponding
+    seek component into:
+      - before: skipped entirely (whole subtree sorts before start)
+      - equal:  yielded, then recursed with the next seek level
+      - after:  yielded normally via walk() (whole subtree sorts after start)
+
+    walk_from(root, root) == walk(root).
+    walk_from(root, start) for start not in walk(root) returns the suffix of
+    walk(root) starting at the first item that sorts >= start.
+    """
+    # Decompose start into path components relative to root, e.g.
+    # root=/a/bs, start=/a/bs/3ab/cd1/rest -> ["3ab", "cd1", "rest"]
+    rel = start.relative_to(root)
+    seek = [c for c in rel.split(sep) if c]
+
+    def _walk_from(directory: Path, depth: int) -> Generator[WalkItem, None, None]:
+        children = directory.dir_list()  # already sorted
+        if depth >= len(seek):
+            # Past all seek components — yield everything under this dir normally.
+            # walk(child) yields child itself then its subtree.
+            for child in children:
+                yield from walk(child)
+            return
+
+        target_name = seek[depth]
+        for child in children:
+            child_name = child.name()
+            if child_name < target_name:
+                continue  # entire subtree sorts before start — skip
+            t = child.ftype()
+            if child_name == target_name:
+                if depth == len(seek) - 1:
+                    # This is the start item itself — yield it and its subtree.
+                    yield (child, t)
+                    if t is DIR:
+                        yield from _walk_from(child, depth + 1)
+                else:
+                    # Intermediate seek directory — appears in oracle before start,
+                    # so do not yield it; just descend to find the start.
+                    if t is DIR:
+                        yield from _walk_from(child, depth + 1)
+            else:
+                # Past the seek boundary — yield this child and its full subtree.
+                yield from walk(child)
+
+    # Yield the start node itself, then use the seek path to pick up everything
+    # from start onward (its own subtree first, then later siblings at each
+    # ancestor level).
+    # Special case: start == root means yield root and everything under it.
+    if start == root:
+        yield (root, root.ftype())
+        yield from _walk_from(root, 0)
+    else:
+        yield from _walk_from(root, 0)
+
+
 def walk_path(item: WalkItem) -> Path:
     return item[0]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,22 +15,108 @@ def client(app):
 
 
 def test_api_blob_list_returns(client):
-    # Empty Depot
+    # Fresh vol has keydb blobs; verify response shape.
     response = client.get("/bs")
     assert response.status_code == 200
-    # assert [] == response.json
+    assert isinstance(response.json["blobs"], list)
+    assert response.json["next"] is None
 
 
 def test_api_blob_list_full(vol, client):
     bloba = build_blob(vol, b"a")
     blobb = build_blob(vol, b"b")
     blobc = build_blob(vol, b"c")
-    # Empty Depot
     response = client.get("/bs")
     assert response.status_code == 200
-    assert bloba in response.json
-    assert blobb in response.json
-    assert blobc in response.json
+    assert bloba in response.json["blobs"]
+    assert blobb in response.json["blobs"]
+    assert blobc in response.json["blobs"]
+    assert response.json["next"] is None
+
+
+def collect_pages(client, max_items):
+    """
+    Consume all pages of GET /bs with the given page size.
+    Asserts paging invariants: each page sorted, no cross-page duplicates,
+    next cursor equals the last item on each page (exclusive for the next call).
+    Returns the concatenated blob list.
+    """
+    all_blobs = []
+    cursor = None
+    while True:
+        qs = {"max_items": max_items}
+        if cursor is not None:
+            qs["start-after"] = cursor
+        r = client.get("/bs", query_string=qs)
+        assert r.status_code == 200
+        page = r.json["blobs"]
+        next_cursor = r.json["next"]
+        assert page == sorted(page), f"page not sorted: {page}"
+        for b in page:
+            assert b not in all_blobs, f"duplicate blob across pages: {b}"
+        # next cursor must equal the last item on the page (exclusive for next call)
+        if next_cursor is not None:
+            assert next_cursor == page[-1], "next cursor must be last item on page"
+        all_blobs.extend(page)
+        cursor = next_cursor
+        if cursor is None:
+            break
+    assert all_blobs == sorted(all_blobs)
+    return all_blobs
+
+
+def test_api_blob_list_paging(vol, client):
+    bloba = build_blob(vol, b"a")
+    blobb = build_blob(vol, b"b")
+    blobc = build_blob(vol, b"c")
+
+    # Ground truth: unpaged (includes keydb blobs).
+    all_blobs = client.get("/bs").json["blobs"]
+    n = len(all_blobs)
+
+    # Page size one less than total forces at least two pages.
+    page_size = max(1, n - 1)
+    collected = collect_pages(client, page_size)
+    assert collected == all_blobs
+    assert bloba in collected
+    assert blobb in collected
+    assert blobc in collected
+
+
+def test_api_blob_list_paging_exact_fit(vol, client):
+    build_blob(vol, b"a")
+    build_blob(vol, b"b")
+
+    all_blobs = client.get("/bs").json["blobs"]
+
+    # Page size == total: all blobs returned, but since len(page) == max_items
+    # we can't know there's no next page without another round-trip.
+    r = client.get("/bs", query_string={"max_items": len(all_blobs)})
+    assert r.status_code == 200
+    assert r.json["blobs"] == all_blobs
+    cursor = r.json["next"]
+    assert cursor == all_blobs[-1]
+
+    # Follow-up with start-after the last blob returns empty with null next.
+    r2 = client.get("/bs", query_string={"start-after": cursor})
+    assert r2.status_code == 200
+    assert r2.json["blobs"] == []
+    assert r2.json["next"] is None
+
+
+def test_api_blob_list_start_after(vol, client):
+    build_blob(vol, b"a")
+    build_blob(vol, b"b")
+    build_blob(vol, b"c")
+
+    all_blobs = client.get("/bs").json["blobs"]
+    # start-after all_blobs[1] should return everything strictly after it
+    cursor = all_blobs[1]
+
+    r = client.get("/bs", query_string={"start-after": cursor})
+    assert r.status_code == 200
+    assert r.json["blobs"] == all_blobs[2:]
+    assert r.json["next"] is None
 
 
 def test_api_blob_create_no_id(vol, client):

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -17,6 +17,8 @@ from farmfs.fs import (
     ensure_link,
     ensure_symlink,
     ensure_rename,
+    walk,
+    walk_from,
 )
 from farmfs.fs import XSym
 import pytest
@@ -960,3 +962,42 @@ def test_extension() -> None:
     assert Path("/foo/bar.txt/").extension() == ".txt"
     assert Path("//foo/bar.txt").extension() == ".txt"
     assert Path("//foo/bar.txt/").extension() == ".txt"
+
+
+# ---------------------------------------------------------------------------
+# walk_from tests
+#
+# Strategy: use a real blobstore (via the vol fixture) so the directory
+# structure matches what FileBlobstore.blobs() will actually walk.  Build
+# enough blobs that several directory levels are populated, get the full
+# walk() result as an oracle, then verify that walk_from(root, start_path)
+# == oracle[i:] for every item i.
+# ---------------------------------------------------------------------------
+
+def test_walk_from_oracle(vol):
+    """walk_from(root, item) must equal walk(root)[i:] for every item i."""
+    from tests.conftest import build_blob
+    from farmfs import getvol
+
+    # Build several blobs to populate the blobstore tree.
+    blobs = [
+        b"alpha", b"beta", b"gamma", b"delta", b"epsilon",
+        b"zeta", b"eta", b"theta",
+    ]
+    for data in blobs:
+        build_blob(vol, data)
+
+    bsvol = getvol(vol)
+    root = bsvol.bs.root
+
+    oracle = list(walk(root))
+    assert len(oracle) > 0
+
+    for i, (start_path, _) in enumerate(oracle):
+        result = list(walk_from(root, start_path))
+        expected = oracle[i:]
+        assert result == expected, (
+            f"walk_from starting at oracle index {i} ({start_path}) gave wrong result.\n"
+            f"  expected: {[str(p) for p, _ in expected]}\n"
+            f"  got:      {[str(p) for p, _ in result]}"
+        )


### PR DESCRIPTION
## Summary

- **New API**: \`GET /bs\` supports cursor-based paging with S3-compatible \`start-after\` semantics
  - \`start-after=<blob>\` — return blobs strictly after this checksum (exclusive, matches S3 \`StartAfter\`)
  - \`max_items=<n>\` — return at most n blobs per page
  - Response: \`{"blobs": [...], "next": "<last-blob-on-page>" | null}\` — \`next\` is null only when fewer than \`max_items\` blobs were returned
- **Efficient seek**: \`walk_from(root, start)\` in \`fs.py\` navigates directly to the right directory subtree, skipping earlier entries without scanning them — O(depth + result) instead of O(total blobs)
- **All three blobstores updated**: \`FileBlobstore\` uses \`walk_from\` + \`islice\`; \`S3Blobstore\` passes \`start_after\` natively to s3lib (no key arithmetic needed); \`HttpBlobstore\` passes params as query strings

## Test plan

- [ ] \`pytest tests/test_api.py\` — paging tests use \`collect_pages()\` to verify sorted order, no cross-page duplicates, cursor equals last item on page
- [ ] \`pytest tests/test_fs.py::test_walk_from_oracle\` — generative test: for every item in \`walk(root)\`, \`walk_from(root, item)\` equals the oracle suffix starting at that item
- [ ] \`make check\` — passes clean (test + typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)