### PR TITLE
detect unfrozen files during snap make; add --allow-dirty and --overwrite

### DIFF
--- a/farmfs/snapshot.py
+++ b/farmfs/snapshot.py
@@ -1,10 +1,17 @@
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from delnone import delnone
 from farmfs.blobstore import ReverserFunction
 from farmfs.fs import Path, LINK, DIR, FILE, SkipFunction, ingest, ROOT, walk
 from functools import total_ordering
 from os.path import sep
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+
+DirtyCallback = Callable[[Path], None]
+
+
+def skip_dirty(path: Path) -> None:
+    """Default dirty callback: silently skip unfrozen files (original behaviour)."""
+    pass
 
 
 @total_ordering
@@ -93,12 +100,14 @@ class Snapshot:
 
 
 class TreeSnapshot(Snapshot):
-    def __init__(self, root: Path, is_ignored: SkipFunction, reverser: ReverserFunction):
+    def __init__(self, root: Path, is_ignored: SkipFunction, reverser: ReverserFunction,
+                 dirty_callback: DirtyCallback = skip_dirty):
         super().__init__("<tree>")
         assert isinstance(root, Path)
         self.root = root
         self.is_ignored = is_ignored
         self.reverser = reverser
+        self.dirty_callback = dirty_callback
 
     def __iter__(self) -> Generator[SnapshotItem, None, None]:
         root = self.root
@@ -115,6 +124,7 @@ class TreeSnapshot(Snapshot):
                 elif type_ is DIR:
                     ud_str = None
                 elif type_ is FILE:
+                    self.dirty_callback(path)
                     continue
                 else:
                     raise ValueError(

--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -112,7 +112,8 @@ Usage:
   farmfs mkfs [options] [--root <root>] [--data <data>]
   farmfs (status|freeze|thaw) [options] [<path>...]
   farmfs snap list [options]
-  farmfs snap (make|read|delete|restore|diff) [options] [--force] <snap>
+  farmfs snap make [options] [--overwrite] [--allow-dirty] <snap>
+  farmfs snap (read|delete|restore|diff) [options] <snap>
   farmfs fsck [options] [--remote=<remote>] [--missing --frozen-ignored --blob-permissions --checksums --keydb] [--fix]
   farmfs count [options]
   farmfs similarity [options] <dir_a> <dir_b>
@@ -832,11 +833,24 @@ def farmfs_ui(argv: List[str], cwd: Path) -> int:
                 print("\n".join(snapdb.list()))
             else:
                 name = args["<snap>"]
-                force = args["--force"]
                 if args["delete"]:
                     snapdb.delete(name)
                 elif args["make"]:
-                    snapdb.write(name, cast(KeySnapshot, vol.tree()), force)
+                    allow_dirty = args["--allow-dirty"]
+                    overwrite = args["--overwrite"]
+                    dirty: List[Path] = []
+                    # Materialise the tree now so dirty_callback fires before we write.
+                    snap_items = list(vol.tree(dirty_callback=dirty.append))
+                    if dirty and not allow_dirty:
+                        for p in dirty:
+                            print("unfrozen:", p.relative_to(cwd))
+                        print("snap aborted: unfrozen files present (use --allow-dirty to proceed)")
+                        return 1
+                    try:
+                        snapdb.write(name, KeySnapshot(snap_items, name, vol.bs.reverser), overwrite)
+                    except ValueError as e:
+                        print(str(e))
+                        return 1
                 else:
                     snap = snapdb.read(name)
                     if args["read"]:

--- a/farmfs/volume.py
+++ b/farmfs/volume.py
@@ -27,7 +27,7 @@ from farmfs.fs import (
     walk,
     walk_path
 )
-from farmfs.snapshot import TreeSnapshot, KeySnapshot, SnapDelta, Snapshot, SnapshotItem, SnapItemTypes
+from farmfs.snapshot import TreeSnapshot, KeySnapshot, SnapDelta, Snapshot, SnapshotItem, SnapItemTypes, DirtyCallback, skip_dirty
 from itertools import chain
 from json import loads
 from typing import Dict, Generator, Iterator, List, Optional, Tuple, TypedDict
@@ -248,11 +248,14 @@ class FarmFSVolume:
         """Returns an iterator which lists all SnapshotItems from all local snaps + the working tree"""
         return pipeline(concat)(self.trees())
 
-    def tree(self) -> Snapshot:
+    def tree(self, dirty_callback: DirtyCallback = skip_dirty) -> Snapshot:
         """
         Get a snap object which represents the tree of the volume.
+
+        dirty_callback -- called with each unfrozen Path encountered during
+                          iteration. Defaults to skip_dirty (silently ignore).
         """
-        tree_snap = TreeSnapshot(self.root, self.is_ignored, reverser=self.bs.reverser)
+        tree_snap = TreeSnapshot(self.root, self.is_ignored, reverser=self.bs.reverser, dirty_callback=dirty_callback)
         return tree_snap
 
     def userdata_csums(self) -> Generator[str, None, None]:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1316,7 +1316,7 @@ def test_farmfs_fetch(vol1: Path, vol2: Path, vol3: Path, capsys):
     build_file(vol2, "b", "world")
     r = farmfs_ui(["freeze", "--quiet"], vol2)
     assert r == 0
-    r = farmfs_ui(["snap", "make", "--force", "release"], vol2)
+    r = farmfs_ui(["snap", "make", "--overwrite", "release"], vol2)
     assert r == 0
 
     # Re-fetch changed snap without --force fails
@@ -1360,3 +1360,67 @@ def test_farmfs_fetch(vol1: Path, vol2: Path, vol3: Path, capsys):
     assert "origin/release" in snap_list
     assert "origin/v2" in snap_list
     assert "other/snap3" in snap_list
+
+
+def test_snap_make_dirty_aborts(vol, capsys):
+    """snap make on a vol with unfrozen files should fail and not write the snap."""
+    build_file(vol, "unfrozen.txt", "hello")
+    r = farmfs_ui(["snap", "make", "mysnap"], vol)
+    captured = capsys.readouterr()
+    assert r != 0
+    assert "unfrozen" in captured.out
+    assert "unfrozen.txt" in captured.out
+    # Snap must not have been written.
+    r2 = farmfs_ui(["snap", "list"], vol)
+    captured2 = capsys.readouterr()
+    assert "mysnap" not in captured2.out
+
+
+def test_snap_make_allow_dirty(vol, capsys):
+    """snap make --allow-dirty should succeed and omit unfrozen files."""
+    build_file(vol, "unfrozen.txt", "hello")
+    build_file(vol, "frozen.txt", "world")
+    farmfs_ui(["freeze", "frozen.txt"], vol)
+    csum = vol.join("frozen.txt").readlink()
+    r = farmfs_ui(["snap", "make", "--allow-dirty", "mysnap"], vol)
+    captured = capsys.readouterr()
+    assert r == 0
+    # The snap must exist.
+    r2 = farmfs_ui(["snap", "list"], vol)
+    captured2 = capsys.readouterr()
+    assert "mysnap" in captured2.out
+    # The frozen file must appear in the snap; the unfrozen one must not.
+    r3 = farmfs_ui(["snap", "read", "mysnap"], vol)
+    captured3 = capsys.readouterr()
+    assert "frozen.txt" in captured3.out
+    assert "unfrozen.txt" not in captured3.out
+
+
+def test_snap_make_overwrite(vol, capsys):
+    """snap make --overwrite should replace an existing snap."""
+    build_file(vol, "a.txt", "v1")
+    farmfs_ui(["freeze"], vol)
+    farmfs_ui(["snap", "make", "mysnap"], vol)
+    # Add another frozen file and overwrite the snap.
+    farmfs_ui(["thaw", "a.txt"], vol)
+    build_file(vol, "a.txt", "v2")
+    farmfs_ui(["freeze"], vol)
+    r = farmfs_ui(["snap", "make", "--overwrite", "mysnap"], vol)
+    captured = capsys.readouterr()
+    assert r == 0
+    r2 = farmfs_ui(["snap", "read", "mysnap"], vol)
+    captured2 = capsys.readouterr()
+    # New snap content reflects v2 checksum (just verify it exists and returns 0).
+    assert r2 == 0
+
+
+def test_snap_make_overwrite_required(vol, capsys):
+    """snap make without --overwrite should fail when snap already exists."""
+    build_file(vol, "a.txt", "v1")
+    farmfs_ui(["freeze"], vol)
+    farmfs_ui(["snap", "make", "mysnap"], vol)
+    farmfs_ui(["thaw", "a.txt"], vol)
+    build_file(vol, "a.txt", "v2")
+    farmfs_ui(["freeze"], vol)
+    r = farmfs_ui(["snap", "make", "mysnap"], vol)
+    assert r != 0


### PR DESCRIPTION
## Summary

- `snap make` now errors on unfrozen (non-frozen, non-ignored) files by default, printing each offending path
- `--allow-dirty` flag to proceed despite unfrozen files
- `--force` renamed to `--overwrite` for clarity
- Single-pass implementation: `DirtyCallback` fires during the same tree walk that builds the snapshot — no race between detection and snapshot creation

## Design

`TreeSnapshot` takes an optional `dirty_callback: DirtyCallback` (a `Callable[[Path], None]`). The default (`skip_dirty`) silently skips FILE-type entries as before. The snap make handler passes `dirty.append` to collect paths in one pass, then checks the list before writing the snapshot.

## Test plan

- [ ] `test_snap_make_dirty_aborts` — unfrozen file causes non-zero exit and prints path
- [ ] `test_snap_make_allow_dirty` — `--allow-dirty` proceeds successfully
- [ ] `test_snap_make_overwrite` — `--overwrite` replaces existing snap
- [ ] `test_snap_make_overwrite_required` — existing snap without `--overwrite` returns non-zero
- [ ] `make check` passes (test + typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)