### PR TITLE
restore SIGPIPE default to suppress broken pipe tracebacks

### DIFF
--- a/farmfs/ui.py
+++ b/farmfs/ui.py
@@ -51,10 +51,14 @@ from farmfs.fs import (
 )
 from json import JSONEncoder
 from s3lib.ui import load_creds as load_s3_creds
+import signal
 import sys
 import tqdm as tqdmlib
 from farmfs.blobstore import FileBlobstore, S3Blobstore, HttpBlobstore
 from farmfs.progress import csum_pbar, diff_pbar, lazy_pbar, list_pbar, tree_pbar
+
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
 
 def noop(x: Any) -> None:
     return None


### PR DESCRIPTION
## Summary

- Installs `signal.SIG_DFL` for `SIGPIPE` at module load in `ui.py`, covering both `farmfs` and `farmdbg` entry points
- When output is piped to `head`, `grep`, etc. and the reader closes early, the process now exits with status 141 instead of printing a `BrokenPipeError` traceback to stderr

## Test plan

- [ ] `farmfs status | head` — no traceback, `${PIPESTATUS[0]}` is 141
- [ ] `make check` passes (tests, mypy, flake8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)